### PR TITLE
Fix file logging sample code.

### DIFF
--- a/doc/source/dev/logging.rst
+++ b/doc/source/dev/logging.rst
@@ -185,7 +185,7 @@ defaults, or via a configuration file.
     defaults = init_defaults('myapp', 'log')
     defaults['log']['file'] = 'my.log'
 
-    app = foundation.CementApp('myapp', defaults=defaults)
+    app = foundation.CementApp('myapp', config_defaults=defaults)
     app.setup()
     app.run()
     app.log.info('This is my info message')


### PR DESCRIPTION
Incorrect defaults configuration key, was 'defaults', should be 'config_defaults'.
Tested with cement 2.2.x on python 2.7 .
