### PR TITLE
Bug fix ext_plugin.py

### DIFF
--- a/cement/ext/ext_plugin.py
+++ b/cement/ext/ext_plugin.py
@@ -86,7 +86,7 @@ class CementPluginHandler(plugin.CementPluginHandler):
                 for key in pconfig.keys(plugin):
                     self.app.config.set(plugin, key, pconfig.get(plugin, key))
             else:
-                self._disabled_plugins.append(section)
+                self._disabled_plugins.append(plugin)
 
     def _load_plugin_from_dir(self, plugin_name, plugin_dir):
         """


### PR DESCRIPTION
If a .conf file exists in the config_dir and it's first section has an enable_plugin key and enable_plugin is not true, the plugin name should be appended to _disabled_plugins, not the last section name from the early section scan (e.g. "log").

Copy-paste error, methinks.
