### PR TITLE
Fix for registering same handler multiple times

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,3 +7,4 @@ documentation, or testing.
     * BJ Dierkes (derks) - Creator, Primary Maintainer
     * Kyle Rockman (rocktavious)
     * Tomasz Czyż (spinus)
+    * Ildar Akhmetgaleev (akhilman)

--- a/cement/core/handler.py
+++ b/cement/core/handler.py
@@ -192,7 +192,7 @@ class HandlerManager(object):
             raise exc.FrameworkError("Handler type '%s' doesn't exist." %
                                      handler_type)
         if obj._meta.label in self.__handlers__[handler_type] and \
-                self.__handlers__[handler_type][obj._meta.label] != obj:
+                self.__handlers__[handler_type][obj._meta.label] != orig_obj:
             raise exc.FrameworkError("handlers['%s']['%s'] already exists" %
                                      (handler_type, obj._meta.label))
 
@@ -203,7 +203,7 @@ class HandlerManager(object):
             LOG.debug("Interface '%s' does not have a validator() function!" %
                       interface)
 
-        self.__handlers__[handler_type][obj.Meta.label] = orig_obj
+        self.__handlers__[handler_type][obj._meta.label] = orig_obj
 
     def registered(self, handler_type, handler_label):
         """


### PR DESCRIPTION
Fix for registering same handler multiple times

fixes #353 

According documentation:

> Register a handler object to a handler.  If the same object is already
        registered then no exception is raised, however if a different object
        attempts to be registered to the same name a ``FrameworkError`` is
        raised.

But it fails. Example code:
```python
from cement.core.interface import Interface
from cement.core.handler import CementBaseHandler
from cement.core.foundation import CementApp


class MyInterface(Interface):

    class IMeta:

        label = 'myinterface'


class MyHandler(CementBaseHandler):

    class Meta:

        interface = MyInterface
        label = 'myhandler'


with CementApp('myapp') as app:

    app.handler.define(MyInterface)
    app.handler.register(MyHandler)
    app.handler.register(MyHandler)

```

To fix it `obj` should be replaced by `orig_obj` in https://github.com/datafolklabs/cement/blob/master/cement/core/handler.py#L195

`self.__handlers__[handler_type][obj.Meta.label] = orig_obj` replaced by `self.__handlers__[handler_type][obj._meta.label] = orig_obj` to maintain consistency. 
