### PR TITLE
Replacing deprecated handler.list()

### DIFF
--- a/cement/core/controller.py
+++ b/cement/core/controller.py
@@ -365,7 +365,7 @@ class CementBaseController(handler.CementBaseHandler):
                 commands.append(func)
 
         # process stacked controllers second for commands and args
-        for contr in handler.list('controller'):
+        for contr in self.app.handler.list('controller'):
             # don't include self here
             if contr == self.__class__:
                 continue


### PR DESCRIPTION
fixes #356 
Replacing deprecated `handler.list()` with `self.app.handler.list()` in [cement.core.controller#L368](https://github.com/datafolklabs/cement/blob/master/cement/core/controller.py#L368)