### PR TITLE
Removing temporary file/dir in test's tearDown

### DIFF
--- a/cement/utils/test.py
+++ b/cement/utils/test.py
@@ -1,5 +1,7 @@
 """Cement testing utilities."""
 
+import os
+import shutil
 import unittest
 from tempfile import mkstemp, mkdtemp
 from ..core import backend, foundation
@@ -49,8 +51,16 @@ class CementTestCase(unittest.TestCase):
 
         """
         self.app = self.make_app()
-        _, self.tmp_file = mkstemp()
-        self.tmp_dir = mkdtemp()
+        _, self.tmp_file = mkstemp(prefix=self.app._meta.label)
+        self.tmp_dir = mkdtemp(prefix=self.app._meta.label)
+
+    def tearDown(self):
+        """
+        Removes temporary files
+        """
+        os.unlink(self.tmp_file)
+        shutil.rmtree(self.tmp_dir)
+
 
     def make_app(self, *args, **kw):
         """


### PR DESCRIPTION
Fixes issue #363
Removing temporary file/dir to prevent cluttering up tmp directory.
Also adding app label as prefixes to temporary file/dir, just for
esthetic.