### PR TITLE
controller: Add support for function doc in expose

### DIFF
--- a/cement/core/controller.py
+++ b/cement/core/controller.py
@@ -171,7 +171,7 @@ class expose(object):
         metadict['func_name'] = func.__name__
         metadict['exposed'] = True
         metadict['hide'] = self.hide
-        metadict['help'] = self.help
+        metadict['help'] = self.help or func.__doc__
         metadict['aliases'] = self.aliases
         metadict['aliases_only'] = self.aliases_only
         metadict['controller'] = None  # added by the controller


### PR DESCRIPTION
This allows for use of the Python builtin documentation string for your exposed methods:

```python
class MyController(CementBaseController):
    class Meta:
        label = 'my_controller'
        # ...

    @expose()
    def list(self):
        """
        My great method.

        This methods does this and that ...
        """
        # ...
```