### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/cement/ext/ext_argcomplete.py
+++ b/cement/ext/ext_argcomplete.py
@@ -1,6 +1,6 @@
 """
 The Argcomplete Extension provides the necessary hooks to utilize
-the `Argcomplete Library <https://argcomplete.readthedocs.org/en/latest/>`_,
+the `Argcomplete Library <https://argcomplete.readthedocs.io/en/latest/>`_,
 and perform auto-completion of command line arguments/options/sub-parsers/etc.
 
 Requirements
@@ -81,7 +81,7 @@ your actual application entry-point name (i.e. ``myapp`` if installed as
                                          default
 
 See the
-`Argcomplete Documentation <https://argcomplete.readthedocs.org/en/latest/>`_
+`Argcomplete Documentation <https://argcomplete.readthedocs.io/en/latest/>`_
 on how to properly integrate it's usage into your application deployment.
 This extension simply enables Argcomplete to do it's thing on application
 startup.

--- a/doc/source/dev/application_design.rst
+++ b/doc/source/dev/application_design.rst
@@ -70,7 +70,7 @@ Multi-File Applications
 
 Larger applications need to be properly organized to keep code clean, and to
 keep a high level of maintainability (read: to keep things from getting
-shitty). `The Boss Project <http://boss.rtfd.org>`_ provides our recommended
+shitty). `The Boss Project <https://boss.readthedocs.io>`_ provides our recommended
 application layout, and is a great starting point for anyone new to Cement.
 
 The primary detail about how to layout your code is this:  All CLI/Cement

--- a/doc/source/dev/boss_templates.rst
+++ b/doc/source/dev/boss_templates.rst
@@ -3,7 +3,7 @@
 Starting Projects from Boss Templates
 =====================================
 
-`The Boss Project <http://boss.rtfd.org>`_ provides 'Baseline Open Source
+`The Boss Project <https://boss.readthedocs.io>`_ provides 'Baseline Open Source
 Software' templates and development tools. It has similarities to PasteScript
 with regards to templating, but far easier to extend.  The official template
 repository includes a number of templates specifically for Cement, and are the

--- a/doc/source/dev/testing.rst
+++ b/doc/source/dev/testing.rst
@@ -12,7 +12,7 @@ performing its own Nose tests.
 For more information on testing, please see the following:
 
  * `UnitTest <http://docs.python.org/library/unittest.html>`_
- * `Nose <http://nose.readthedocs.org/en/latest/>`_
+ * `Nose <https://nose.readthedocs.io/en/latest/>`_
  * `Coverage <http://nedbatchelder.com/code/coverage/>`_
  
 API Reference:


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.