### PR TITLE
Support for cythonized Plugins

### DIFF
--- a/cement/ext/ext_plugin.py
+++ b/cement/ext/ext_plugin.py
@@ -162,27 +162,26 @@ class CementPluginHandler(plugin.CementPluginHandler):
          exists.
 
         """
-        paths = [
-            os.path.join(plugin_dir, "%s.py" % plugin_name),
-            os.path.join(plugin_dir, plugin_name, "__init__.py")
-        ]
 
-        for path in paths:
-            LOG.debug("attempting to load '%s' from '%s'" % (plugin_name,
-                                                             path))
-            if os.path.exists(path):
-                # We don't catch this because it would make debugging a
-                # nightmare
-                f, path, desc = imp.find_module(plugin_name, [plugin_dir])
-                mod = imp.load_module(plugin_name, f, path, desc)
-                if mod and hasattr(mod, 'load'):
-                    mod.load(self.app)
-                return True
+        LOG.debug("attempting to load '%s' from '%s'" % (plugin_name,
+                                                         plugin_dir))
+        if not os.path.exists(plugin_dir):
+            LOG.debug("plugin directory '%s' does not exist." % plugin_dir)
+            return False
 
-        LOG.debug("plugin '%s' does not exist in '%s'." %
-                  (plugin_name, plugin_dir))
+        try:
+            f, path, desc = imp.find_module(plugin_name, [plugin_dir])
+        except ImportError:
+            LOG.debug("plugin '%s' does not exist in '%s'." %
+                      (plugin_name, plugin_dir))
+            return False
 
-        return False
+        # We don't catch this because it would make debugging a
+        # nightmare
+        mod = imp.load_module(plugin_name, f, path, desc)
+        if mod and hasattr(mod, 'load'):
+            mod.load(self.app)
+        return True
 
     def _load_plugin_from_bootstrap(self, plugin_name, base_package):
         """


### PR DESCRIPTION
fixes #380

Support for all kind of pre-compiled plugins. Should work with all platforms.

Note: `imp` module is deprecated in python-3.5

This is how --debug log looks:
```
2016-07-07 16:11:24,068 (DEBUG) cement.ext.ext_plugin : loading application plugin 'cplug'
2016-07-07 16:11:24,068 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,069 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug.abi3.so'
2016-07-07 16:11:24,069 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug.so'
2016-07-07 16:11:24,069 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug.py'
2016-07-07 16:11:24,069 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug.pyc'
2016-07-07 16:11:24,069 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/var/lib/plugtest/plugins/cplug/__init__.py'
2016-07-07 16:11:24,070 (DEBUG) cement.ext.ext_plugin : plugin 'cplug' does not exist in '/var/lib/plugtest/plugins'.
2016-07-07 16:11:24,070 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/home/ildar/.plugtest/plugins/cplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,070 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/home/ildar/.plugtest/plugins/cplug.abi3.so'
2016-07-07 16:11:24,070 (DEBUG) cement.ext.ext_plugin : attempting to load 'cplug' from '/home/ildar/.plugtest/plugins/cplug.so'
2016-07-07 16:11:24,072 (DEBUG) cement.core.handler : registering handler '<class 'cplug.CPlugPluginController'>' into handlers['controller']['cplug']
2016-07-07 16:11:24,073 (DEBUG) cement.core.hook : registering hook 'cplug_plugin_hook' from cplug into hooks['post_argument_parsing']
2016-07-07 16:11:24,073 (DEBUG) cement.ext.ext_plugin : loading application plugin 'dplug'
2016-07-07 16:11:24,073 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,073 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug.abi3.so'
2016-07-07 16:11:24,074 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug.so'
2016-07-07 16:11:24,074 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug.py'
2016-07-07 16:11:24,074 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug.pyc'
2016-07-07 16:11:24,075 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/var/lib/plugtest/plugins/dplug/__init__.py'
2016-07-07 16:11:24,075 (DEBUG) cement.ext.ext_plugin : plugin 'dplug' does not exist in '/var/lib/plugtest/plugins'.
2016-07-07 16:11:24,075 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,076 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug.abi3.so'
2016-07-07 16:11:24,076 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug.so'
2016-07-07 16:11:24,076 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug.py'
2016-07-07 16:11:24,076 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug.pyc'
2016-07-07 16:11:24,076 (DEBUG) cement.ext.ext_plugin : attempting to load 'dplug' from '/home/ildar/.plugtest/plugins/dplug/__init__.py'
2016-07-07 16:11:24,078 (DEBUG) cement.core.handler : registering handler '<class 'dplug.DPlugPluginController'>' into handlers['controller']['dplug']
2016-07-07 16:11:24,079 (DEBUG) cement.core.hook : registering hook 'dplug_plugin_hook' from dplug into hooks['post_argument_parsing']
2016-07-07 16:11:24,079 (DEBUG) cement.ext.ext_plugin : loading application plugin 'fplug'
2016-07-07 16:11:24,080 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,080 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug.abi3.so'
2016-07-07 16:11:24,080 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug.so'
2016-07-07 16:11:24,081 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug.py'
2016-07-07 16:11:24,081 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug.pyc'
2016-07-07 16:11:24,081 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/var/lib/plugtest/plugins/fplug/__init__.py'
2016-07-07 16:11:24,081 (DEBUG) cement.ext.ext_plugin : plugin 'fplug' does not exist in '/var/lib/plugtest/plugins'.
2016-07-07 16:11:24,082 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/home/ildar/.plugtest/plugins/fplug.cpython-35m-x86_64-linux-gnu.so'
2016-07-07 16:11:24,082 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/home/ildar/.plugtest/plugins/fplug.abi3.so'
2016-07-07 16:11:24,082 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/home/ildar/.plugtest/plugins/fplug.so'
2016-07-07 16:11:24,083 (DEBUG) cement.ext.ext_plugin : attempting to load 'fplug' from '/home/ildar/.plugtest/plugins/fplug.py'
2016-07-07 16:11:24,084 (DEBUG) cement.core.handler : registering handler '<class 'fplug.FPlugPluginController'>' into handlers['controller']['fplug']
2016-07-07 16:11:24,085 (DEBUG) cement.core.hook : registering hook 'fplug_plugin_hook' from fplug into hooks['post_argument_parsing']
```

<!---
@huboard:{"order":137.02740137,"milestone_order":382,"custom_state":""}
-->
