### PR TITLE
Fix typo 'Hander' in interfaces_and_handler docs

### DIFF
--- a/doc/source/dev/interfaces_and_handlers.rst
+++ b/doc/source/dev/interfaces_and_handlers.rst
@@ -333,7 +333,7 @@ it to ``CementApp``:
     app = CementApp('myapp', log_handler=MyLogHandler)
 
 
-Hander Default Configuration Settings
+Handler Default Configuration Settings
 -------------------------------------
 
 All handlers can define default config file settings via their


### PR DESCRIPTION
Resolves issue #392 
Fixed a simple typo of the word 'Handler' (was 'Hander') inside of the 'interfaces_and_handler' documentation.