### PR TITLE
Fix for #415. app.extend and reusing app

### DIFF
--- a/cement/core/foundation.py
+++ b/cement/core/foundation.py
@@ -955,6 +955,9 @@ class CementApp(meta.MetaMixin):
         for res in self.hook.run('post_close', self):
             pass
 
+        for member in self._extended_members:
+            delattr(self, member)
+
         if code is not None:
             assert type(code) == int, \
                 "Invalid exit status code (must be integer)"


### PR DESCRIPTION
Removing all extended members from app during close()