### PR TITLE
extensions load to honor config_section

### DIFF
--- a/cement/core/foundation.py
+++ b/cement/core/foundation.py
@@ -1304,7 +1304,7 @@ class CementApp(meta.MetaMixin):
                     setattr(self._meta, key, base_dict[key])
 
         # load extensions from configuraton file
-        if 'extensions' in self.config.keys(self._meta.label):
+        if 'extensions' in self.config.keys(self._meta.config_section):
             exts = self.config.get(self._meta.label, 'extensions')
 
             # convert a comma-separated string to a list


### PR DESCRIPTION
If changing Meta: config_section of a CementApp it fails to run() with raising `ConfigParser.NoSectionError: No section: '..'`. 

This seems to fix that, through probably it would make sense to use the base_dict above, but I did not want to touch code I barely know :)