### PR TITLE
Add QLDS Manager to Projects Built on Cement

### DIFF
--- a/doc/source/projects_built_on_cement.rst
+++ b/doc/source/projects_built_on_cement.rst
@@ -12,6 +12,7 @@ Built on Cement™:
  * `SentientHome <https://github.com/fxstein/SentientHome>`_
  * `Pubkey <https://github.com/fxstein/pubkey>`_
  * `HCE Project <http://hce-project.com/>`_
+ * `QLDS Manager <https://qlds-manager.readthedocs.io/en/stable/index.html>`_ (`GitHub <https://github.com/rzeka/QLDS-Manager>`_)
  
 
  If you are building a project on the Cement Framework and would like to see


### PR DESCRIPTION
Add the QLDS Manager for Quake Live Server administrators to the list of
projects built with Cement. Closes #472.