### PR TITLE
Made changes to 'Doc - Quick Start' for crossplatform compatibility.

### DIFF
--- a/doc/source/dev/quickstart.rst
+++ b/doc/source/dev/quickstart.rst
@@ -139,7 +139,7 @@ config creation, and logging.
         class Meta:
             label = 'myapp'
             config_defaults = defaults
-            extensions = ['daemon', 'memcached', 'json', 'yaml']
+            extensions = ['memcached', 'json', 'yaml']
             hooks = [
                 ('pre_close', my_cleanup_hook),
             ]


### PR DESCRIPTION
This PR addresses issue #443 fixing the [Quick Start](http://cement.readthedocs.io/en/latest/dev/quickstart/) example being cross platform compatible, by removing `daemon` from `extensions` in the example code under the [Getting Warmer](http://cement.readthedocs.io/en/latest/dev/quickstart/#getting-warmer) section.