### PR TITLE
Fix wrong property name: exit_on_close

### DIFF
--- a/cement/cli/templates/generate/project/{{ label }}/main.py
+++ b/cement/cli/templates/generate/project/{{ label }}/main.py
@@ -19,7 +19,7 @@ class {{ class_name }}(App):
         config_defaults = CONFIG
 
         # call sys.exit() on close
-        close_on_exit = True
+        exit_on_close = True
 
         # load additional framework extensions
         extensions = [


### PR DESCRIPTION
**NOTICE:** Prior to submitting a pull request, please ensure you abide by the
[Guidelines for Code Contributions], including but not limited to:

- PR is associated with at least one issue
- Submit from a **topic** branch, not a pre-existing Cement branch
- Make every effort to comply with [PEP8]
- All tests pass successfully
- Coverage reports 100% code coverage

---

**Issue:** #551


[Guidelines for Code Contributions]: https://github.com/datafolklabs/cement/blob/master/.github/CONTRIBUTING.md#guidelines-for-code-contributions
[PEP8]: http://www.python.org/dev/peps/pep-0008/
