### PR TITLE
Update pip setup.py command in templates (fixes #588)

### DIFF
--- a/cement/cli/templates/generate/project/README.md
+++ b/cement/cli/templates/generate/project/README.md
@@ -5,7 +5,7 @@
 ```
 $ pip install -r requirements.txt
 
-$ pip install setup.py
+$ python setup.py install
 ```
 
 ## Development

--- a/cement/cli/templates/generate/todo-tutorial/README.md
+++ b/cement/cli/templates/generate/todo-tutorial/README.md
@@ -5,7 +5,7 @@
 ```
 $ pip install -r requirements.txt
 
-$ pip install setup.py
+$ python setup.py install
 ```
 
 ## Development


### PR DESCRIPTION
**Issue:** #588 

Use `python setup.py install` instead of `pip install setup.py` in the templates.