### PR TITLE
Extend ext_smtp.py

### DIFF
--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -157,12 +157,12 @@ class SMTPMailHandler(mail.MailHandler):
             partText = MIMEText(body)
         elif isinstance(body, list):
             if len(body) >= 1:
-                partText = MIMEText(body[0])
+                partText = MIMEText(body[0], 'plain')
             if len(body) >= 2:
                 partHtml = MIMEText(body[1], 'html')
         elif isinstance(body, dict):
             if 'text' in body:
-                partText = MIMEText(body['text'])
+                partText = MIMEText(body['text'], 'plain')
             if 'html' in body:
                 partHtml = MIMEText(body['html'], 'html')
         if partText:
@@ -172,7 +172,7 @@ class SMTPMailHandler(mail.MailHandler):
         # loop files
         for path in params['files']:
             part = MIMEBase('application', 'octet-stream')
-            # test seperate disposition name (filename.ext=attname.ext)
+            # test filename for a seperate attachement disposition name (filename.ext=attname.ext)
             filename = os.path.basename(path)
             # test for divider in filename
             i = filename.find('=')

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -172,7 +172,8 @@ class SMTPMailHandler(mail.MailHandler):
         # loop files
         for path in params['files']:
             part = MIMEBase('application', 'octet-stream')
-            # test filename for a seperate attachement disposition name (filename.ext=attname.ext)
+            # test filename for a seperate attachement disposition name
+            # like (filename.ext=attname.ext)
             filename = os.path.basename(path)
             # test for divider in filename
             i = filename.find('=')

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -55,7 +55,7 @@ class SMTPMailHandler(mail.MailHandler):
 
         # some keyword args override configuration defaults
         for item in ['to', 'from_addr', 'cc', 'bcc', 'subject',
-                        'subject_prefix', 'files']:
+                     'subject_prefix', 'files']:
             config_item = self.app.config.get(self._meta.config_section, item)
             params[item] = kw.get(item, config_item)
 

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -172,8 +172,7 @@ class SMTPMailHandler(mail.MailHandler):
         # loop files
         for path in params['files']:
             part = MIMEBase('application', 'octet-stream')
-            # test filename for a seperate attachement 
-            # disposition name (filename.ext=attname.ext)
+            # test seperate disposition name (filename.ext=attname.ext)
             filename = os.path.basename(path)
             # test for divider in filename
             i = filename.find('=')

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -172,7 +172,8 @@ class SMTPMailHandler(mail.MailHandler):
         # loop files
         for path in params['files']:
             part = MIMEBase('application', 'octet-stream')
-            # test filename for a seperate attachement disposition name (filename.ext=attname.ext)
+            # test filename for a seperate attachement 
+            # disposition name (filename.ext=attname.ext)
             filename = os.path.basename(path)
             # test for divider in filename
             i = filename.find('=')
@@ -180,7 +181,7 @@ class SMTPMailHandler(mail.MailHandler):
             if i < 0:
                 attname = filename
             else:
-                attname = filename[i + 1 :]
+                attname = filename[i+1:]
                 filename = filename[0:i]
                 # update the filename to read from
                 path = os.path.dirname(path) + '/' + filename
@@ -189,7 +190,10 @@ class SMTPMailHandler(mail.MailHandler):
                 part.set_payload(file.read())
             # encode and name
             encoders.encode_base64(part)
-            part.add_header('Content-Disposition', f'attachment; filename={attname}')
+            part.add_header(
+                'Content-Disposition',
+                f'attachment; filename={attname}',
+            )
             msg.attach(part)
 
         server.send_message(msg)

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -47,13 +47,15 @@ class SMTPMailHandler(mail.MailHandler):
             'auth': False,
             'username': None,
             'password': None,
+            'files': None,
         }
 
     def _get_params(self, **kw):
         params = dict()
 
         # some keyword args override configuration defaults
-        for item in ['to', 'from_addr', 'cc', 'bcc', 'subject']:
+        for item in ['to', 'from_addr', 'cc', 'bcc', 'subject',
+                        'subject_prefix', 'files']:
             config_item = self.app.config.get(self._meta.config_section, item)
             params[item] = kw.get(item, config_item)
 
@@ -63,15 +65,6 @@ class SMTPMailHandler(mail.MailHandler):
         for item in other_params:
             params[item] = self.app.config.get(self._meta.config_section,
                                                item)
-
-        # also grab the subject_prefix
-        params['subject_prefix'] = self.app.config.get(
-            self._meta.config_section,
-            'subject_prefix'
-        )
-
-        # allow files to append
-        params['files'] = kw.get('files', [])
 
         return params
 
@@ -170,31 +163,32 @@ class SMTPMailHandler(mail.MailHandler):
         if partHtml:
             msg.attach(partHtml)
         # loop files
-        for path in params['files']:
-            part = MIMEBase('application', 'octet-stream')
-            # test filename for a seperate attachement disposition name
-            # like (filename.ext=attname.ext)
-            filename = os.path.basename(path)
-            # test for divider in filename
-            i = filename.find('=')
-            # split attname from filename
-            if i < 0:
-                attname = filename
-            else:
-                attname = filename[i+1:]
-                filename = filename[0:i]
-                # update the filename to read from
-                path = os.path.dirname(path) + '/' + filename
-            # add attachment
-            with open(path, 'rb') as file:
-                part.set_payload(file.read())
-            # encode and name
-            encoders.encode_base64(part)
-            part.add_header(
-                'Content-Disposition',
-                f'attachment; filename={attname}',
-            )
-            msg.attach(part)
+        if params['files']:
+            for path in params['files']:
+                part = MIMEBase('application', 'octet-stream')
+                # test filename for a seperate attachement disposition name
+                # like (filename.ext=attname.ext)
+                filename = os.path.basename(path)
+                # test for divider in filename
+                i = filename.find('=')
+                # split attname from filename
+                if i < 0:
+                    attname = filename
+                else:
+                    attname = filename[i+1:]
+                    filename = filename[0:i]
+                    # update the filename to read from
+                    path = os.path.dirname(path) + '/' + filename
+                # add attachment
+                with open(path, 'rb') as file:
+                    part.set_payload(file.read())
+                # encode and name
+                encoders.encode_base64(part)
+                part.add_header(
+                    'Content-Disposition',
+                    f'attachment; filename={attname}',
+                )
+                msg.attach(part)
 
         server.send_message(msg)
 


### PR DESCRIPTION
1. Respect empty CC and BCC and do not deliver <> to SMTP Server
2. Allow TLS also on non-SSL sessions
3. Turn on debugging before TLS to see that log as well
4. Check for parameter `files` and empty if missed
5. Loop through files and append to attachments
6. Allow Attachment Disposition Name differ from Filename by path/filename.ext=attname.ext
7. Allow body to send in text and html by list or dict

---

**Covered Issues:** 

1. #667 
1. #668 
