### PR TITLE
BUG FIX and updates ext_smtp.py

### DIFF
--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -4,12 +4,16 @@ Cement smtp extension module.
 
 from __future__ import annotations
 import os
+from datetime import datetime, timezone
 import smtplib
 from email.header import Header
+from email.charset import Charset, BASE64, QP
 from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email.mime.text import MIMEText
+from email.mime.image import MIMEImage
 from email import encoders
+from email.utils import format_datetime, make_msgid
 from typing import Any, Dict, Union, Tuple, TYPE_CHECKING
 from ..core import mail
 from ..utils import fs
@@ -54,6 +58,14 @@ class SMTPMailHandler(mail.MailHandler):
             'username': None,
             'password': None,
             'files': None,
+            # define controlling of mail encoding
+            'charset': 'utf-8',
+            'header_encoding': None,
+            'body_encoding': None,
+            'date_enforce': True,
+            'msgid_enforce': True,
+            'msgid_str': None,
+            'msgid_domain': None,
         }
 
     _meta: Meta  # type: ignore
@@ -62,17 +74,35 @@ class SMTPMailHandler(mail.MailHandler):
         params = dict()
 
         # some keyword args override configuration defaults
-        for item in ['to', 'from_addr', 'cc', 'bcc', 'subject',
-                     'subject_prefix', 'files']:
+        for item in [
+            'to', 'from_addr', 'cc', 'bcc', 'subject', 'subject_prefix', 'files',
+            'charset', 'header_encoding', 'body_encoding',
+            'date_enforce', 'msgid_enforce', 'msgid_str',
+        ]:
             config_item = self.app.config.get(self._meta.config_section, item)
             params[item] = kw.get(item, config_item)
 
         # others don't
-        other_params = ['ssl', 'tls', 'host', 'port', 'auth', 'username',
-                        'password', 'timeout']
-        for item in other_params:
-            params[item] = self.app.config.get(self._meta.config_section,
-                                               item)
+        for item in [
+            'ssl', 'tls', 'host', 'port', 'auth', 'username', 'password',
+            'timeout', 'msgid_domain'
+        ]:
+            params[item] = self.app.config.get(self._meta.config_section, item)
+
+        # some are only set by message
+        for item in [
+            'date', 'message_id', 'return_path', 'reply_to'
+        ]:
+            value = kw.get(item, None)
+            if value is not None and str.strip(f'{value}') != '':
+                params[item] = kw.get(item, config_item)
+
+        # take all X-headers as is
+        for item in kw.keys():
+            if len(item) > 2 and item.startswith(('x-', 'X-', 'x_', 'X_')):
+                value = kw.get(item, None)
+                if value is not None:
+                    params[f'X-{item[2:]}'] = value
 
         return params
 
@@ -143,17 +173,81 @@ class SMTPMailHandler(mail.MailHandler):
         if is_true(params['auth']):
             server.login(params['username'], params['password'])
 
-        res = self._send_message(server, body, **params)
+        msg = self._make_message(body, **params)
+        res = server.send_message(msg)
+
         server.quit()
+
+        # FIXME: how to check success? docs don't say return type
+        # - `[ext.scrub]` [Issue #724](https://github.com/datafolklabs/cement/issues/724)
         return res
 
-    def _send_message(self,
-                      server: Union[smtplib.SMTP, smtplib.SMTP_SSL],
-                      body: Union[str, Tuple[str, str]],
-                      **params: Any) -> bool:
-        msg = MIMEMultipart('alternative')
-        msg.set_charset('utf-8')
+    def _header(self, value, _charset=None, **params):
+        return Header(value, charset=_charset) if params['header_encoding'] else value
 
+    def _make_message(self, body, **params):
+        # use encoding for header parts
+        cs_header = Charset(params['charset'])
+        if params['header_encoding'] == 'base64':
+            cs_header.header_encoding = BASE64
+        elif params['header_encoding'] == 'qp' or params['body_encoding'] == 'quoted-printable':
+            cs_header.header_encoding = QP
+
+        # use encoding for body parts
+        cs_body = Charset(params['charset'])
+        if params['body_encoding'] == 'base64':
+            cs_body.body_encoding = BASE64
+        elif params['body_encoding'] == 'qp' or params['body_encoding'] == 'quoted-printable':
+            cs_body.body_encoding = QP
+
+        # setup body parts
+        partText = None
+        partHtml = None
+
+        if type(body) not in [str, tuple, dict]:
+            error_msg = "Message body must be string, " \
+                        "tuple ('<text>', '<html>') or " \
+                        "dict {'text': '<text>', 'html': '<html>'}"
+            raise TypeError(error_msg)
+        
+        if isinstance(body, str):
+            partText = MIMEText(body, 'plain', _charset=cs_body)
+        elif isinstance(body, tuple):
+            # handle plain text
+            if len(body) >= 1 and body[0] and str.strip(body[0]) != '':
+                partText = MIMEText(str.strip(body[0]), 'plain', _charset=cs_body)
+            # handle html
+            if len(body) >= 2 and body[1] and str.strip(body[1]) != '':
+                partHtml = MIMEText(str.strip(body[1]), 'html', _charset=cs_body)
+        elif isinstance(body, dict):
+            # handle plain text
+            if 'text' in body and str.strip(body['text']) != '':
+                partText = MIMEText(str.strip(body['text']), 'plain', _charset=cs_body)
+            # handle html
+            if 'html' in body and str.strip(body['html']) != '':
+                partHtml = MIMEText(str.strip(body['html']), 'html', _charset=cs_body)
+
+        # To define the correct message content-type
+        # we need to indentify the content of this mail.
+        # If only "text" exists => text/plain, if only
+        # "html" exists => text/html, if "text" and
+        # "html" exists => multipart/alternative. In
+        # any case that files exists => multipart/mixed.
+        # Set message charset and encoding based on parts
+        if params['files']:
+            msg = MIMEMultipart('mixed')
+            msg.set_charset(params['charset'])
+        elif partText and partHtml:
+            msg = MIMEMultipart('alternative')
+            msg.set_charset(params['charset'])
+        elif partHtml:
+            msg = MIMEBase('text', 'html')
+            msg.set_charset(cs_body)
+        else:
+            msg = MIMEBase('text', 'plain')
+            msg.set_charset(cs_body)
+
+        # create message
         msg['From'] = params['from_addr']
         msg['To'] = ', '.join(params['to'])
         if params['cc']:
@@ -161,73 +255,164 @@ class SMTPMailHandler(mail.MailHandler):
         if params['bcc']:
             msg['Bcc'] = ', '.join(params['bcc'])
         if params['subject_prefix'] not in [None, '']:
-            subject = f"{params['subject_prefix']} {params['subject']}"
+            msg['Subject'] = self._header(f"{params['subject_prefix']} {params['subject']}", _charset=cs_header, **params)
         else:
-            subject = params['subject']
-        msg['Subject'] = Header(subject)  # type: ignore
+            msg['Subject'] = self._header(params['subject'], _charset=cs_header, **params)
 
-        # add body as text and/or as html
-        partText = None
-        partHtml = None
+        # check for date
+        if is_true(params['date_enforce']) and not params.get('date', None):
+            params['date'] = format_datetime(datetime.now(timezone.utc))
+        # check for message-id
+        if is_true(params['msgid_enforce']) and not params.get('message_id', None):
+            params['message_id'] = make_msgid(params['msgid_str'], params['msgid_domain'])
 
-        if type(body) not in [str, tuple]:
-            error_msg = "Message body must be string or tuple " \
-                        "('<text>', '<html>')"
-            raise TypeError(error_msg)
+        # check for message headers
+        if params.get('date', None):
+            msg['Date'] = params['date']
+        if params.get('message_id', None):
+            msg['Message-Id'] = params['message_id']
+        if params.get('return_path', None):
+            msg['Return-Path'] = params['return_path']
+        if params.get('reply_to', None):
+            msg['Reply-To'] = params['reply_to']
 
-        if isinstance(body, str):
-            partText = MIMEText(body)
-        elif isinstance(body, tuple):
-            # handle plain text
-            if len(body) >= 1:
-                partText = MIMEText(body[0], 'plain')
+        # check for X-headers
+        for item in params.keys():
+            if item.startswith('X-'):
+                msg.add_header(item.title(), self._header(f'{params[item]}', _charset=cs_header, **params))
 
-            # handle html
-            if len(body) >= 2:
-                partHtml = MIMEText(body[1], 'html')
-
-        if partText:
-            msg.attach(partText)
-        if partHtml:
-            msg.attach(partHtml)
+        # append the body parts
+        if params['files']:
+            # multipart/mixed
+            if partHtml:
+                # when html exists, create always a related part to include
+                # the body alternatives and eventually files as related
+                # attachments (e.g. images).
+                rel = MIMEMultipart('related')
+                # create an alternative part to include bodies for text and html
+                alt = MIMEMultipart('alternative')
+                # body text and body html
+                if partText:
+                    alt.attach(partText)
+                alt.attach(partHtml)
+                rel.attach(alt)
+                msg.attach(rel)
+            else:
+                # only body text or no body
+                if partText:
+                    msg.attach(partText)
+                else:
+                    # no body no files = empty message = just headers
+                    pass
+        else:
+            # multipart/alternative
+            if partText and partHtml:
+                # plain/text and plain/html
+                msg.attach(partText)
+                msg.attach(partHtml)
+            else:
+                # plain/text or plain/html only so just append payload
+                if partText:
+                    msg.set_payload(partText.get_payload(), charset=cs_body)
+                elif partHtml:
+                    msg.set_payload(partHtml.get_payload(), charset=cs_body)
+                else:
+                    # no body no files = empty message = just headers
+                    pass
 
         # attach files
         if params['files']:
             for in_path in params['files']:
-                part = MIMEBase('application', 'octet-stream')
-
-                # support for alternative file name if its tuple
-                # like ('alt-name.ext', '/path/to/file.ext')
+                # support for alternative file name if its tuple or dict
+                # like [
+                #       'path/simple.ext',
+                #       ('attname.ext', 'path/filename.ext'),
+                #       ('attname.ext', 'path/filename.ext', 'cidname'),
+                #       {'name': 'attname', 'path': 'path/filename.ext', cid: 'cidname'},
+                #      ]
                 if isinstance(in_path, tuple):
-                    if in_path[0] == in_path[1]:
-                        # protect against the full path being passed in
-                        alt_name = os.path.basename(in_path[0])
-                    else:
-                        alt_name = in_path[0]
+                    attname = in_path[0]
                     path = in_path[1]
+                    cid = in_path[2] if len(in_path) >= 3 else None
+                elif isinstance(in_path, dict):
+                    attname = in_path.get('name', None)
+                    path = in_path.get('path')
+                    cid = in_path.get('cid', None)
                 else:
-                    alt_name = os.path.basename(in_path)
+                    attname = None
                     path = in_path
+                    cid = None
 
                 path = fs.abspath(path)
+                if not attname:
+                    attname = os.path.basename(path)
 
-                # add attachment
+                # add attachment payload from file
                 with open(path, 'rb') as file:
-                    part.set_payload(file.read())
+                    # check for embedded image or regular attachments
+                    if cid:
+                        part = MIMEImage(file.read())
+                    else:
+                        part = MIMEBase('application', 'octet-stream')
+                        part.set_payload(file.read())
 
-                # encode and name
+                # encoder
                 encoders.encode_base64(part)
-                part.add_header(
-                    'Content-Disposition',
-                    f'attachment; filename={alt_name}',
-                )
-                msg.attach(part)
 
-        server.send_message(msg)
+                # embedded inline or attachment
+                if cid:
+                    part.add_header(
+                        'Content-Disposition',
+                        f'inline; filename={attname}',
+                    )
+                    part.add_header('Content-ID', f'<{cid}>')
+                    rel.attach(part)
+                else:
+                    # attname header
+                    part.add_header(
+                        'Content-Disposition',
+                        f'attachment; filename={attname}',
+                    )
+                    msg.attach(part)
 
-        # FIXME: how to check success? docs don't say return type
-        # - `[ext.scrub]` [Issue #724](https://github.com/datafolklabs/cement/issues/724)
-        return True
+        return msg
+
+    def send_by_template(self, template, data={}, **kw):
+        # test if template exists by loading it
+        def _template_exists(template):
+            # check if stored in cache already
+            if template in self._template_exists_cache:
+                return self._template_exists_cache[template]
+            # do first time check from file or module
+            result = False
+            try:
+                # successfully load when available
+                self.app.template.load(template)
+                result = True
+            except:
+                pass
+            # store flag in cache list to prevent often load access
+            self._template_exists_cache[template] = result
+            # return state
+            return result
+
+        # prepare email params
+        params = dict(**kw)
+        # check render subject
+        if 'subject' not in params:
+            if _template_exists(f'{template}.title.jinja2'):
+                params['subject'] = self.app.render(data, f'{template}.title.jinja2', out=None)
+        # build body
+        body = list()
+        if _template_exists(f'{template}.plain.jinja2'):
+            body.append(self.app.render(dict(**data, mail_params=params), f'{template}.plain.jinja2', out=None))
+        if _template_exists(f'{template}.html.jinja2'):
+            # before adding a html part make sure that plain part exists
+            if len(body) == 0:
+                body.append('Content is delivered as HTML only.')
+            body.append(self.app.render(dict(**data, mail_params=params), f'{template}.html.jinja2', out=None))
+        # send the message
+        self.send(body=body, **params)
 
 
 def load(app: App) -> None:


### PR DESCRIPTION
Dear @derks 

I post this PR and do not expect that you will accept or include all changes. Let's start discussing about it. But let mw note, that the changes are completely backwards compatible and won't break any existing code so far as I can see currently.

I also will attach comments to specific code line to let you know my intentions with the changes.

---

<br />

## 1. Bug fix for "Content-Type"

With our last patch on this file we didn't take care of some mail conditions and so, in the moment, the created mails are malformed, when sending partText, partHtml and include some files.

it will send

```
Content-Type: multipart/mixed; boundary=...

==...==
Content-Type: plain/text

==...==
Content-Type: plain/html

==...==
Content-Type: application/octet-stream

==...==--
```

Most Email providers and clients will show a correct view of the intended message but not IOS nor Apple iMail (anymore). Those will only show the attachment(s) but not the message.

To send such kind of mails, the structure has to be:

```
Content-Type: multipart/mixed; boundary=...

==...==
Content-Type: multipart/related; boundary=REL

==REL==
Content-Type: multipart/alternative; boundary=ALT

==ALT==
Content-Type: plain/text

==ALT==
Content-Type: plain/html

==ALT==--

==REL==--

==...==
Content-Type: application/octet-stream

==...==--
```

Sending like that all client show up the correct mail. Current (malformed) mails get also some minor SPAM value, while I can see a number of mails not reaching the recipients.

<br />

<br />

## 2. Optimizing Content-Types

Working on correct mail structures, I figured out that:

a. Mails with only text should stay simply text/plain
b. Mails with only html should stay simply text/html
c. Mails with only text and html should stay simply multipart/alternative with text/plain and text/html containers
d. Mails with only text and files can stay with multipart/mixed only
e. Mails with text, html and files should show structure as above
f. Mails with html can contain inline images

So for this rules, I changed the handling of message parts and when and how they will get attached into each other. 

<br />

<br />

## 3. Optimizing Content-Encoding

When sending out mails sometimes you will encode the body parts (and or some of the headers) not per default as SHORT but defined as QP or as BASE64.

So with new configs `header_encoding` and `body_encoding` (None, 'qp', 'base64') that can be configured per default an per message.

<br />

<br />

## 4. X-Headers

For some reason a message needs to set own X-Header fields for messaging. Currently those will not pass thru the message while `_get_params` will remove them.

I added them.

<br />

<br />

## 5. Message-Id and Date

A message should have under "normal" conditions at least a Date when sent and a Message-Id. There are new configs to enforce this Headers and or to vary there values.

---

<br />

<br />

## Why I coded things like I did.

I moved the creation of the `partText` and `partHtml` to the top of the function, because I need the information what was created to define the Message itself like multipart/x etc.

Also I changed the name `_send_message` into `_make_message` and return the `msg` object to `send` method. This makes it easier to write tests for the `_make_message` method. Also it makes more sense to me, that `send` will do also `server.send()`.

---

<br />

Looking forward to your replies. Please check also me notes on the code.

Kindly
Tom



