### PR TITLE
fix __all__

### DIFF
--- a/cement/__init__.py
+++ b/cement/__init__.py
@@ -10,3 +10,21 @@ from .ext.ext_argparse import expose as ex
 from .utils.misc import init_defaults, minimal_logger
 from .utils import misc, fs, shell
 from .utils.version import get_version
+
+__all__ = [
+    "App",
+    "TestApp",
+    "Interface",
+    "Handler",
+    "FrameworkError",
+    "InterfaceError",
+    "CaughtSignal",
+    "Controller",
+    "ex",
+    "init_defaults",
+    "minimal_logger",
+    "misc",
+    "fs",
+    "shell",
+    "get_version",
+]


### PR DESCRIPTION
**Issue:**

```python
from cement import TestApp
```

```
src/.../test.py:7: error: Module "cement" does not explicitly export attribute "TestApp"  [attr-defined]
```


[Guidelines for Code Contributions]: https://github.com/datafolklabs/cement/blob/master/.github/CONTRIBUTING.md#guidelines-for-code-contributions
[PEP8]: http://www.python.org/dev/peps/pep-0008/
