### PR TITLE
refactor(ext.smtp): cleanup ext smtp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Refactoring:
 
 - `[ext.smtp]` PEP 8 naming, idiomatic string methods, and cleaner type validation
 - `[ext.smtp]` Refactor `_make_message` into focused private methods
+- `[ext.smtp]` Simplify X-header normalization and preserve original casing
 - `[dev]` Python 3.14 Default Development Target
 - `[dev]` Remove Support for Python 3.8 (EOL)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Refactoring:
 
 Misc:
 
-- None
+- `[ext.smtp]` Isolate test defaults to prevent cross-test state pollution
 
 Deprecations:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Features:
 Refactoring:
 
 - `[ext.smtp]` PEP 8 naming, idiomatic string methods, and cleaner type validation
+- `[ext.smtp]` Refactor `_make_message` into focused private methods
 - `[dev]` Python 3.14 Default Development Target
 - `[dev]` Remove Support for Python 3.8 (EOL)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Features:
 
 Refactoring:
 
+- `[ext.smtp]` PEP 8 naming, idiomatic string methods, and cleaner type validation
 - `[dev]` Python 3.14 Default Development Target
 - `[dev]` Remove Support for Python 3.8 (EOL)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 Bugs:
 
-- None
+- `[ext.smtp]` Fix `timeout` passed as `local_hostname` in SMTP constructors
+- `[ext.smtp]` Fix stale variable reference in `_get_params` for per-message headers
+- `[ext.smtp]` Fix SMTP connection leak when send fails with an exception
+- `[ext.smtp]` Fix unconditional error log on every send (now only logs on errors)
 
 Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Misc:
 
 Deprecations:
 
-- None
+- `[ext.smtp]` `SMTPMailHandler.send()` returning `bool` is deprecated; will return `senderrs` dict in a future version
 
 
 ## 3.0.14 - May 5, 2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Bugs:
 - `[ext.smtp]` Fix stale variable reference in `_get_params` for per-message headers
 - `[ext.smtp]` Fix SMTP connection leak when send fails with an exception
 - `[ext.smtp]` Fix unconditional error log on every send (now only logs on errors)
+- `[ext.smtp]` Fix header encoding incorrectly affected by `body_encoding` setting
 
 Features:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,14 @@ When working with extensions:
 - Optional dependencies declared in pyproject.toml under `[project.optional-dependencies]`
 - Extensions follow naming pattern `ext_<name>.py`
 - Must implement proper interface contracts
+
+## GitHub Project
+
+This project is hosted at **github.com/datafolklabs/cement**. Use the `gh` CLI to interact with GitHub issues, pull requests, and other project resources.
+
+- `gh issue list -R datafolklabs/cement` - List open issues
+- `gh issue view <number> -R datafolklabs/cement` - View a specific issue
+- `gh pr list -R datafolklabs/cement` - List open pull requests
+- `gh pr view <number> -R datafolklabs/cement` - View a specific PR
+- `gh pr checks <number> -R datafolklabs/cement` - View CI status for a PR
+- `gh api repos/datafolklabs/cement/pulls/<number>/comments` - View PR review comments

--- a/cement/core/deprecations.py
+++ b/cement/core/deprecations.py
@@ -5,6 +5,7 @@ DEPRECATIONS = {
     '3.0.8-1': "Environment variable CEMENT_FRAMEWORK_LOGGING is deprecated in favor of CEMENT_LOG, and will be removed in Cement v3.2.0",  # noqa: E501
     '3.0.8-2': "App.Meta.framework_logging will be changed or removed in Cement v3.2.0",  # noqa: E501
     '3.0.10-1': "The FATAL logging facility is deprecated in favor of CRITICAL, and will be removed in future versions of Cement.",  # noqa: E501
+    '3.0.16-1': "SMTPMailHandler.send() returning bool is deprecated. It will return the smtplib senderrs dict in a future version of Cement",  # noqa: E501
 }
 
 

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -183,10 +183,9 @@ class SMTPMailHandler(mail.MailHandler):
         # For smtplib this would be "senderrs" (dict), but for backward compat
         # we need to return bool
         # https://github.com/python/cpython/blob/3.13/Lib/smtplib.py#L899
-        if len(res) > 0:
+        if len(res) > 0:  # pragma: nocover - Mailpit accepts everything
             self.app.log.error(f"SMTPHandler Errors: {res}")
-            # this will be difficult to test with Mailpit as it accepts everything... no cover
-            return False  # pragma: nocover
+            return False
         else:
             return True
 

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -193,46 +193,44 @@ class SMTPMailHandler(mail.MailHandler):
         header = Header(value, charset=_charset) if params['header_encoding'] else value
         return header  # type: ignore
 
-    def _make_message(self, body: Union[str, Tuple[str, str]], **params: Dict[str, Any]) \
-                      -> MIMEMultipart:
-        # use encoding for header parts
+    def _build_charsets(self, **params: Dict[str, Any]) -> Tuple[Charset, Charset]:
+        """Build charset objects for header and body encoding."""
         cs_header = Charset(params['charset'])  # type: ignore
         if params['header_encoding'] == 'base64':
             cs_header.header_encoding = BASE64
         elif params['header_encoding'] == 'qp' or params['header_encoding'] == 'quoted-printable':
             cs_header.header_encoding = QP
 
-        # use encoding for body parts
         cs_body = Charset(params['charset'])  # type: ignore
         if params['body_encoding'] == 'base64':
             cs_body.body_encoding = BASE64
         elif params['body_encoding'] == 'qp' or params['body_encoding'] == 'quoted-printable':
             cs_body.body_encoding = QP
 
-        # setup body parts
+        return cs_header, cs_body
+
+    def _build_body_parts(self, body: Union[str, Tuple[str, str]],
+                          cs_body: Charset) -> Tuple[Optional[MIMEText], Optional[MIMEText]]:
+        """Parse body into text and html MIME parts."""
         part_text = None
         part_html = None
 
         if isinstance(body, str):
             part_text = MIMEText(body, 'plain', _charset=cs_body)  # type: ignore
         elif isinstance(body, tuple):
-            # handle plain text
             if len(body) >= 1 and body[0] and body[0].strip() != '':
                 part_text = MIMEText(body[0].strip(),
                                      'plain',
                                      _charset=cs_body)  # type: ignore
-            # handle html
             if len(body) >= 2 and body[1] and body[1].strip() != '':
                 part_html = MIMEText(body[1].strip(),
                                      'html',
                                      _charset=cs_body)  # type: ignore
         elif isinstance(body, dict):
-            # handle plain text
             if 'text' in body and body['text'].strip() != '':
                 part_text = MIMEText(body['text'].strip(),
                                      'plain',
                                      _charset=cs_body)
-            # handle html
             if 'html' in body and body['html'].strip() != '':
                 part_html = MIMEText(body['html'].strip(), 'html', _charset=cs_body)
         else:
@@ -242,13 +240,17 @@ class SMTPMailHandler(mail.MailHandler):
                 "dict {'text': '<text>', 'html': '<html>'}"
             )
 
-        # To define the correct message content-type
-        # we need to indentify the content of this mail.
+        return part_text, part_html
+
+    def _build_mime_structure(self, part_text: Optional[MIMEText],
+                              part_html: Optional[MIMEText],
+                              cs_body: Charset,
+                              **params: Dict[str, Any]) -> MIMEMultipart:
+        """Select the correct MIME container based on content and attachments."""
         # If only "text" exists => text/plain, if only
         # "html" exists => text/html, if "text" and
         # "html" exists => multipart/alternative. In
         # any case that files exists => multipart/mixed.
-        # Set message charset and encoding based on parts
         if params['files']:
             msg = MIMEMultipart('mixed')
             msg.set_charset(params['charset'])  # type: ignore
@@ -262,7 +264,11 @@ class SMTPMailHandler(mail.MailHandler):
             msg = MIMEBase('text', 'plain')  # type: ignore
             msg.set_charset(cs_body)
 
-        # create message
+        return msg
+
+    def _set_headers(self, msg: MIMEMultipart, cs_header: Charset,
+                     **params: Dict[str, Any]) -> None:
+        """Set all message headers including addresses, dates, and X-headers."""
         msg['From'] = params['from_addr']  # type: ignore
         msg['To'] = ', '.join(params['to'])
         if params['cc']:
@@ -277,15 +283,13 @@ class SMTPMailHandler(mail.MailHandler):
                                           _charset=cs_header,
                                           **params)
 
-        # check for date
+        # auto-generate date and message-id if enforced and not provided
         if is_true(params['date_enforce']) and not params.get('date', None):
             params['date'] = format_datetime(datetime.now(timezone.utc))  # type: ignore
-        # check for message-id
         if is_true(params['msgid_enforce']) and not params.get('message_id', None):
             params['message_id'] = make_msgid(params['msgid_str'],  # type: ignore
                                               params['msgid_domain'])  # type: ignore
 
-        # check for message headers
         if params.get('date', None):
             msg['Date'] = params['date']  # type: ignore
         if params.get('message_id', None):
@@ -295,107 +299,108 @@ class SMTPMailHandler(mail.MailHandler):
         if params.get('reply_to', None):
             msg['Reply-To'] = params['reply_to']  # type: ignore
 
-        # check for X-headers
+        # X-headers
         for item in params.keys():
             if item.startswith('X-'):
                 msg.add_header(item.title(),
                                self._header(f'{params[item]}',  # type: ignore
                                             _charset=cs_header, **params))
 
-        # append the body parts
+    def _attach_body(self, msg: MIMEMultipart, part_text: Optional[MIMEText],
+                     part_html: Optional[MIMEText], cs_body: Charset,
+                     **params: Dict[str, Any]) -> None:
+        """Attach body parts to the message with correct MIME structure."""
         if params['files']:
             # multipart/mixed
             if part_html:
-                # when html exists, create always a related part to include
+                # when html exists, create a related part to include
                 # the body alternatives and eventually files as related
                 # attachments (e.g. images).
                 rel = MIMEMultipart('related')
-                # create an alternative part to include bodies for text and html
                 alt = MIMEMultipart('alternative')
-                # body text and body html
                 if part_text:
                     alt.attach(part_text)
                 alt.attach(part_html)
                 rel.attach(alt)
                 msg.attach(rel)
             else:
-                # only body text or no body
                 if part_text:
                     msg.attach(part_text)
                 else:
-                    # no body no files = empty message = just headers
                     pass  # pragma: no cover
         else:
-            # multipart/alternative
             if part_text and part_html:
-                # plain/text and plain/html
                 msg.attach(part_text)
                 msg.attach(part_html)
             else:
-                # plain/text or plain/html only so just append payload
                 if part_text:
                     msg.set_payload(part_text.get_payload(), charset=cs_body)
                 elif part_html:
                     msg.set_payload(part_html.get_payload(), charset=cs_body)
                 else:
-                    # no body no files = empty message = just headers
                     pass  # pragma: no cover
 
-        # attach files
-        if params['files']:
-            for in_path in params['files']:
-                # support for alternative file name if its tuple or dict
-                # like [
-                #       'path/simple.ext',
-                #       ('altname.ext', 'path/filename.ext'),
-                #       ('altname.ext', 'path/filename.ext', 'content_id'),
-                #       {'name': 'altname', 'path': 'path/filename.ext', cid: 'cidname'},
-                #      ]
-                if isinstance(in_path, tuple):
-                    altname = os.path.basename(in_path[0])
-                    path = in_path[1]
-                    cid = in_path[2] if len(in_path) >= 3 else None
-                elif isinstance(in_path, dict):
-                    altname = os.path.basename(in_path.get('name', None))
-                    path = in_path.get('path')
-                    cid = in_path.get('cid', None)
-                else:
-                    altname = None
-                    path = in_path
-                    cid = None
+    def _attach_files(self, msg: MIMEMultipart, **params: Dict[str, Any]) -> None:
+        """Attach file attachments to the message."""
+        if not params['files']:
+            return
 
-                path = fs.abspath(path)
-                if not altname:
-                    altname = os.path.basename(path)
+        for in_path in params['files']:
+            # support for alternative file name if its tuple or dict
+            # like [
+            #       'path/simple.ext',
+            #       ('altname.ext', 'path/filename.ext'),
+            #       ('altname.ext', 'path/filename.ext', 'content_id'),
+            #       {'name': 'altname', 'path': 'path/filename.ext', cid: 'cidname'},
+            #      ]
+            if isinstance(in_path, tuple):
+                altname = os.path.basename(in_path[0])
+                path = in_path[1]
+                cid = in_path[2] if len(in_path) >= 3 else None
+            elif isinstance(in_path, dict):
+                altname = os.path.basename(in_path.get('name', None))
+                path = in_path.get('path')
+                cid = in_path.get('cid', None)
+            else:
+                altname = None
+                path = in_path
+                cid = None
 
-                # add attachment payload from file
-                with open(path, 'rb') as file:
-                    # check for embedded image or regular attachments
-                    if cid:
-                        part = MIMEImage(file.read())
-                    else:
-                        part = MIMEBase('application', 'octet-stream')
-                        part.set_payload(file.read())
+            path = fs.abspath(path)
+            if not altname:
+                altname = os.path.basename(path)
 
-                # encoder
-                encoders.encode_base64(part)
-
-                # embedded inline or attachment
+            # add attachment payload from file
+            with open(path, 'rb') as file:
                 if cid:
-                    part.add_header(
-                        'Content-Disposition',
-                        f'inline; filename={altname}',
-                    )
-                    part.add_header('Content-ID', f'<{cid}>')
-                    msg.attach(part)
+                    part = MIMEImage(file.read())
                 else:
-                    # altname header
-                    part.add_header(
-                        'Content-Disposition',
-                        f'attachment; filename={altname}',
-                    )
-                    msg.attach(part)
+                    part = MIMEBase('application', 'octet-stream')
+                    part.set_payload(file.read())
 
+            encoders.encode_base64(part)
+
+            if cid:
+                part.add_header(
+                    'Content-Disposition',
+                    f'inline; filename={altname}',
+                )
+                part.add_header('Content-ID', f'<{cid}>')
+            else:
+                part.add_header(
+                    'Content-Disposition',
+                    f'attachment; filename={altname}',
+                )
+            msg.attach(part)
+
+    def _make_message(self, body: Union[str, Tuple[str, str]], **params: Dict[str, Any]) \
+                      -> MIMEMultipart:
+        cs_header, cs_body = self._build_charsets(**params)
+        part_text, part_html = self._build_body_parts(body, cs_body)
+        msg = self._build_mime_structure(part_text, part_html, cs_body, **params)
+        self._set_headers(msg, cs_header, **params)
+        self._attach_body(msg, part_text, part_html, cs_body, **params)
+        self._attach_files(msg, **params)
         return msg
 
 

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -92,7 +92,7 @@ class SMTPMailHandler(mail.MailHandler):
         # some are only set by message
         for item in ['date', 'message_id', 'return_path', 'reply_to']:
             value = kw.get(item, None)
-            if value is not None and str.strip(f'{value}') != '':
+            if value is not None and f'{value}'.strip() != '':
                 params[item] = value
 
         # take all X-headers as is
@@ -210,37 +210,37 @@ class SMTPMailHandler(mail.MailHandler):
             cs_body.body_encoding = QP
 
         # setup body parts
-        partText = None
-        partHtml = None
-
-        if type(body) not in [str, tuple, dict]:
-            error_msg = "Message body must be string, " \
-                        "tuple ('<text>', '<html>') or " \
-                        "dict {'text': '<text>', 'html': '<html>'}"
-            raise TypeError(error_msg)
+        part_text = None
+        part_html = None
 
         if isinstance(body, str):
-            partText = MIMEText(body, 'plain', _charset=cs_body)  # type: ignore
+            part_text = MIMEText(body, 'plain', _charset=cs_body)  # type: ignore
         elif isinstance(body, tuple):
             # handle plain text
-            if len(body) >= 1 and body[0] and str.strip(body[0]) != '':
-                partText = MIMEText(str.strip(body[0]),
-                                    'plain',
-                                    _charset=cs_body)  # type: ignore
+            if len(body) >= 1 and body[0] and body[0].strip() != '':
+                part_text = MIMEText(body[0].strip(),
+                                     'plain',
+                                     _charset=cs_body)  # type: ignore
             # handle html
-            if len(body) >= 2 and body[1] and str.strip(body[1]) != '':
-                partHtml = MIMEText(str.strip(body[1]),
-                                    'html',
-                                    _charset=cs_body)  # type: ignore
+            if len(body) >= 2 and body[1] and body[1].strip() != '':
+                part_html = MIMEText(body[1].strip(),
+                                     'html',
+                                     _charset=cs_body)  # type: ignore
         elif isinstance(body, dict):
             # handle plain text
-            if 'text' in body and str.strip(body['text']) != '':
-                partText = MIMEText(str.strip(body['text']),
-                                              'plain',
-                                              _charset=cs_body)
+            if 'text' in body and body['text'].strip() != '':
+                part_text = MIMEText(body['text'].strip(),
+                                     'plain',
+                                     _charset=cs_body)
             # handle html
-            if 'html' in body and str.strip(body['html']) != '':
-                partHtml = MIMEText(str.strip(body['html']), 'html', _charset=cs_body)
+            if 'html' in body and body['html'].strip() != '':
+                part_html = MIMEText(body['html'].strip(), 'html', _charset=cs_body)
+        else:
+            raise TypeError(
+                "Message body must be string, "
+                "tuple ('<text>', '<html>') or "
+                "dict {'text': '<text>', 'html': '<html>'}"
+            )
 
         # To define the correct message content-type
         # we need to indentify the content of this mail.
@@ -252,10 +252,10 @@ class SMTPMailHandler(mail.MailHandler):
         if params['files']:
             msg = MIMEMultipart('mixed')
             msg.set_charset(params['charset'])  # type: ignore
-        elif partText and partHtml:
+        elif part_text and part_html:
             msg = MIMEMultipart('alternative')
             msg.set_charset(params['charset'])  # type: ignore
-        elif partHtml:
+        elif part_html:
             msg = MIMEBase('text', 'html')  # type: ignore
             msg.set_charset(cs_body)
         else:
@@ -305,7 +305,7 @@ class SMTPMailHandler(mail.MailHandler):
         # append the body parts
         if params['files']:
             # multipart/mixed
-            if partHtml:
+            if part_html:
                 # when html exists, create always a related part to include
                 # the body alternatives and eventually files as related
                 # attachments (e.g. images).
@@ -313,30 +313,30 @@ class SMTPMailHandler(mail.MailHandler):
                 # create an alternative part to include bodies for text and html
                 alt = MIMEMultipart('alternative')
                 # body text and body html
-                if partText:
-                    alt.attach(partText)
-                alt.attach(partHtml)
+                if part_text:
+                    alt.attach(part_text)
+                alt.attach(part_html)
                 rel.attach(alt)
                 msg.attach(rel)
             else:
                 # only body text or no body
-                if partText:
-                    msg.attach(partText)
+                if part_text:
+                    msg.attach(part_text)
                 else:
                     # no body no files = empty message = just headers
                     pass  # pragma: no cover
         else:
             # multipart/alternative
-            if partText and partHtml:
+            if part_text and part_html:
                 # plain/text and plain/html
-                msg.attach(partText)
-                msg.attach(partHtml)
+                msg.attach(part_text)
+                msg.attach(part_html)
             else:
                 # plain/text or plain/html only so just append payload
-                if partText:
-                    msg.set_payload(partText.get_payload(), charset=cs_body)
-                elif partHtml:
-                    msg.set_payload(partHtml.get_payload(), charset=cs_body)
+                if part_text:
+                    msg.set_payload(part_text.get_payload(), charset=cs_body)
+                elif part_html:
+                    msg.set_payload(part_html.get_payload(), charset=cs_body)
                 else:
                     # no body no files = empty message = just headers
                     pass  # pragma: no cover

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -95,12 +95,14 @@ class SMTPMailHandler(mail.MailHandler):
             if value is not None and f'{value}'.strip() != '':
                 params[item] = value
 
-        # take all X-headers as is
+        # take all X-headers, normalizing the prefix to 'X-' and
+        # converting underscores to hyphens in the header name
         for item in kw.keys():
             if len(item) > 2 and item.startswith(('x-', 'X-', 'x_', 'X_')):
                 value = kw.get(item, None)
                 if value is not None:
-                    params[f'X-{item[2:]}'] = value
+                    header_name = f'X-{item[2:].replace("_", "-")}'
+                    params[header_name] = value
 
         return params
 
@@ -302,7 +304,7 @@ class SMTPMailHandler(mail.MailHandler):
         # X-headers
         for item in params.keys():
             if item.startswith('X-'):
-                msg.add_header(item.title(),
+                msg.add_header(item,
                                self._header(f'{params[item]}',  # type: ignore
                                             _charset=cs_header, **params))
 

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -93,7 +93,7 @@ class SMTPMailHandler(mail.MailHandler):
         for item in ['date', 'message_id', 'return_path', 'reply_to']:
             value = kw.get(item, None)
             if value is not None and str.strip(f'{value}') != '':
-                params[item] = kw.get(item, config_item)
+                params[item] = value
 
         # take all X-headers as is
         for item in kw.keys():
@@ -152,36 +152,37 @@ class SMTPMailHandler(mail.MailHandler):
         if is_true(params['ssl']):
             server = smtplib.SMTP_SSL(params['host'],
                                       params['port'],
-                                      params['timeout'])
+                                      timeout=params['timeout'])
             LOG.debug(f"{self._meta.label} : initiating smtp over ssl")
 
         else:
             server = smtplib.SMTP(params['host'],  # type: ignore
                                   params['port'],
-                                  params['timeout'])
+                                  timeout=params['timeout'])
             LOG.debug(f"{self._meta.label} : initiating smtp")
 
-        if self.app.debug is True:
-            server.set_debuglevel(9)
+        try:
+            if self.app.debug is True:
+                server.set_debuglevel(9)
 
-        if is_true(params['tls']):
-            LOG.debug(f"{self._meta.label} : initiating tls")
-            server.starttls()
+            if is_true(params['tls']):
+                LOG.debug(f"{self._meta.label} : initiating tls")
+                server.starttls()
 
-        if is_true(params['auth']):
-            server.login(params['username'], params['password'])
+            if is_true(params['auth']):
+                server.login(params['username'], params['password'])
 
-        msg = self._make_message(body, **params)
-        res = server.send_message(msg)
-
-        server.quit()
+            msg = self._make_message(body, **params)
+            res = server.send_message(msg)
+        finally:
+            server.quit()
 
         # FIXME: should deprecate for 3.0 and change in 3.2
         # For smtplib this would be "senderrs" (dict), but for backward compat
         # we need to return bool
         # https://github.com/python/cpython/blob/3.13/Lib/smtplib.py#L899
-        self.app.log.error(f"SMTPHandler Errors: {res}")
         if len(res) > 0:
+            self.app.log.error(f"SMTPHandler Errors: {res}")
             # this will be difficult to test with Mailpit as it accepts everything... no cover
             return False  # pragma: nocover
         else:

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -199,7 +199,7 @@ class SMTPMailHandler(mail.MailHandler):
         cs_header = Charset(params['charset'])  # type: ignore
         if params['header_encoding'] == 'base64':
             cs_header.header_encoding = BASE64
-        elif params['header_encoding'] == 'qp' or params['body_encoding'] == 'quoted-printable':
+        elif params['header_encoding'] == 'qp' or params['header_encoding'] == 'quoted-printable':
             cs_header.header_encoding = QP
 
         # use encoding for body parts

--- a/cement/ext/ext_smtp.py
+++ b/cement/ext/ext_smtp.py
@@ -16,6 +16,7 @@ from email import encoders
 from email.utils import format_datetime, make_msgid
 from typing import Any, Optional, Dict, Union, Tuple, TYPE_CHECKING
 from ..core import mail
+from ..core.deprecations import deprecate
 from ..utils import fs
 from ..utils.misc import minimal_logger, is_true
 
@@ -179,10 +180,10 @@ class SMTPMailHandler(mail.MailHandler):
         finally:
             server.quit()
 
-        # FIXME: should deprecate for 3.0 and change in 3.2
-        # For smtplib this would be "senderrs" (dict), but for backward compat
-        # we need to return bool
+        # Deprecation: bool return will change to senderrs dict
         # https://github.com/python/cpython/blob/3.13/Lib/smtplib.py#L899
+        deprecate('3.0.16-1')
+
         if len(res) > 0:  # pragma: nocover - Mailpit accepts everything
             self.app.log.error(f"SMTPHandler Errors: {res}")
             return False

--- a/tests/ext/test_ext_smtp.py
+++ b/tests/ext/test_ext_smtp.py
@@ -4,6 +4,7 @@ import mock
 import requests
 import json
 import png
+import warnings
 from time import sleep
 from pytest import raises
 from cement.utils.test import TestApp
@@ -610,3 +611,19 @@ def test_mock_smtp_auth(rando):
             instance = mock_smtp.return_value
             assert instance.login.call_count == 1
             assert instance.send_message.call_count == 1
+
+
+def test_smtp_send_deprecation_warning():
+    defaults = init_defaults('mail.smtp')
+    defaults['mail.smtp']['subject'] = 'test_deprecation'
+    defaults['mail.smtp']['subject_prefix'] = 'UNIT TEST >'
+
+    with mock.patch('smtplib.SMTP'):
+        with SMTPApp(config_defaults=defaults) as app:
+            app.run()
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                app.mail.send('TEST MESSAGE',
+                              to=['me@localhost'],
+                              from_addr='noreply@localhost')
+                assert any("3.0.16-1" in str(warning.message) for warning in w)

--- a/tests/ext/test_ext_smtp.py
+++ b/tests/ext/test_ext_smtp.py
@@ -16,12 +16,18 @@ else:
 
 
 mailpit_api = f'http://{smtp_host}:8025/api/v1'
-defaults = init_defaults('mail.smtp')
-defaults['mail.smtp']['host'] = smtp_host
-defaults['mail.smtp']['port'] = 1025
-defaults['mail.smtp']['to'] = 'noreply@localhost'
-defaults['mail.smtp']['from_addr'] = 'nobody@localhost'
-defaults['mail.smtp']['subject_prefix'] = 'UNIT TEST >'
+
+
+def _get_defaults(subject=None):
+    defaults = init_defaults('mail.smtp')
+    defaults['mail.smtp']['host'] = smtp_host
+    defaults['mail.smtp']['port'] = 1025
+    defaults['mail.smtp']['to'] = 'noreply@localhost'
+    defaults['mail.smtp']['from_addr'] = 'nobody@localhost'
+    defaults['mail.smtp']['subject_prefix'] = 'UNIT TEST >'
+    if subject is not None:
+        defaults['mail.smtp']['subject'] = subject
+    return defaults
 
 
 class SMTPApp(TestApp):
@@ -46,7 +52,7 @@ def delete_msg(message_id):
 
 
 def test_smtp_send(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -71,7 +77,7 @@ def test_smtp_send(rando):
 
 
 def test_smtp_send_with_message_id(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -93,7 +99,7 @@ def test_smtp_send_with_message_id(rando):
 
 
 def test_smtp_send_with_return_path(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -115,7 +121,7 @@ def test_smtp_send_with_return_path(rando):
 
 
 def test_smtp_send_with_reply_to(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -136,7 +142,7 @@ def test_smtp_send_with_reply_to(rando):
 
 
 def test_smtp_send_with_x_headers(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -158,7 +164,7 @@ def test_smtp_send_with_x_headers(rando):
 
 
 def test_smtp_send_with_base64_encoding(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -180,7 +186,7 @@ def test_smtp_send_with_base64_encoding(rando):
 
 
 def test_smtp_send_with_qp_encoding(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -202,7 +208,7 @@ def test_smtp_send_with_qp_encoding(rando):
 
 
 def test_smtp_html(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -226,7 +232,7 @@ def test_smtp_html(rando):
 
 
 def test_smtp_dict_text_and_html(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -254,7 +260,7 @@ def test_smtp_dict_text_and_html(rando):
 
 
 def test_smtp_dict_html_only(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -277,7 +283,7 @@ def test_smtp_dict_html_only(rando):
 
 
 def test_smtp_html_bad_body_type(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -289,7 +295,7 @@ def test_smtp_html_bad_body_type(rando):
 
 
 def test_smtp_cc_bcc(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -315,7 +321,7 @@ def test_smtp_cc_bcc(rando):
 
 
 def test_smtp_files(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -340,7 +346,7 @@ def test_smtp_files(rando, tmp):
 
 
 def test_smtp_dict_and_files(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -369,7 +375,7 @@ def test_smtp_dict_and_files(rando, tmp):
 
 
 def test_smtp_files_alt_name(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -391,7 +397,7 @@ def test_smtp_files_alt_name(rando, tmp):
 
 
 def test_smtp_image_files_as_dict(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     image_file = os.path.join(tmp.dir, 'gradient.png')
     # create a png (coverage)
@@ -427,7 +433,7 @@ def test_smtp_image_files_as_dict(rando, tmp):
 
 
 def test_smtp_image_files_as_dict_inline(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     image_file = os.path.join(tmp.dir, 'gradient.png')
     # create a png (coverage)
@@ -458,7 +464,7 @@ def test_smtp_image_files_as_dict_inline(rando, tmp):
 
 
 def test_smtp_files_path_does_not_exist(rando, tmp):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -472,7 +478,7 @@ def test_smtp_files_path_does_not_exist(rando, tmp):
 def test_smtp_files_alt_name_is_path(rando, tmp):
     # ensure only the basename of file is set if full path is passed as alt
     # name
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
 
     with SMTPApp(config_defaults=defaults) as app:
         app.run()
@@ -494,7 +500,7 @@ def test_smtp_files_alt_name_is_path(rando, tmp):
 
 
 def test_smtp_tls(rando):
-    defaults['mail.smtp']['subject'] = rando
+    defaults = _get_defaults(subject=rando)
     defaults['mail.smtp']['tls'] = True
 
     with SMTPApp(config_defaults=defaults, debug=True) as app:


### PR DESCRIPTION
## Summary

Comprehensive bugfix, refactor, and deprecation pass on the SMTP mail extension (cement/ext/ext_smtp.py).

## Bugs Fixed

- timeout passed as local_hostname — SMTP/SMTP_SSL constructors received timeout as the 3rd positional arg, which is actually local_hostname; now passed as keyword arg
- Stale variable reference in _get_params — per-message headers (date, message_id, return_path, reply_to) could silently receive the wrong value from a leftover loop variable
- SMTP connection leak — if login(), _make_message(), or send_message() raised, server.quit() was never called; now wrapped in try/finally
- Unconditional error log — app.log.error() fired on every send, including successful ones; now only logs when there are actual errors
- Header/body encoding cross-contamination — header_encoding charset was incorrectly set to QP when only body_encoding was quoted-printable

## Refactoring

- Decomposed _make_message (150-line monolith) into focused private methods: _build_charsets, _build_body_parts, _build_mime_structure, _set_headers, _attach_body, _attach_files
- PEP 8 naming — partText/partHtml → part_text/part_html
- Idiomatic Python — str.strip(x) → x.strip(); redundant type() check replaced with else clause on existing isinstance chain
- X-header normalization — consolidated in _get_params (underscores → hyphens), removed .title() call that could mangle acronyms (e.g. X-API-Key → X-Api-Key)

## Test Improvements

- Replaced shared mutable module-level defaults dict with a _get_defaults() helper, eliminating implicit ordering dependencies between tests

## Deprecations

- SMTPMailHandler.send() returning bool is deprecated (3.0.16-1); will return the smtplib senderrs dict in a future version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed SMTP connection leaks when send operations fail
  * Corrected SMTP timeout parameter handling
  * Resolved SMTP header encoding issues
  * Fixed stale parameter references affecting per-message headers

* **Deprecations**
  * SMTPMailHandler.send() returning a boolean is deprecated; future versions will return a dictionary instead

* **Documentation**
  * Added GitHub Project and CLI usage instructions

* **Tests**
  * Improved test isolation to prevent state pollution between tests
  * Added deprecation warning validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->