### PR TITLE
feat(ext.argparse): add read-only _command_meta accessor (#670)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -227,6 +227,13 @@ Features:
   dispatched command and never raises. Additive — the `func()` dispatch
   signature is unchanged.
   - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
+- `[ext.argparse]` Add a companion read-only `_default_command_meta`
+  property on `ArgparseController` that resolves the controller's default
+  sub-command meta (via `Meta.default_func`), since `_command_meta` is
+  `None` while the default function runs (argparse has no native default
+  sub-command). Returns `None` when `default_func` is `None` or points to a
+  non-exposed function (e.g. the stock `_default`); never raises.
+  - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
 
 Refactoring:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,14 @@ Features:
   prompt text and vars-style input.
   - [Issue #782](https://github.com/datafolklabs/cement/issues/782)
   - [PR #780](https://github.com/datafolklabs/cement/pull/780)
+- `[ext.argparse]` Add a read-only `_command_meta` property on
+  `ArgparseController` so an exposed command can read its own `CommandMeta`
+  (label, `parser_options['help']`, etc.) from inside its body via
+  `self._command_meta`, replacing the brittle
+  `getattr(self, ...).__cement_meta__` dance. Returns `None` outside a
+  dispatched command and never raises. Additive — the `func()` dispatch
+  signature is unchanged.
+  - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
 
 Refactoring:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,26 @@ When working with extensions:
 - Body lines: max 78 characters (wrap longer prose at 78)
 - Use `make commit` (runs `pdm run cz commit`) to author commits interactively
 
+## Branching Policy
+
+- **NEVER commit directly to `main` without explicit consent.** This includes
+  implementation, tests, docs, AND planning artifacts (`docs(NN.N):`,
+  `docs(state):`, etc.) — planning commits are work too.
+- **Branch immediately when work begins** — at the start of planning a phase or
+  task, not at execution time. The branch is the unit of consent; everything for
+  a phase (plan + execute) belongs on it.
+- Branch naming: `gsd/phase-{phase}-{slug}` for phase work; otherwise a short,
+  descriptive `feat/...`, `fix/...`, or `docs/...` slug.
+- If you discover you are on `main` with uncommitted or committed work that was
+  not consented to, STOP and surface it: create a branch capturing the work,
+  then propose restoring `main` before doing anything else.
+- The GSD `branching_strategy` config defaults to `none`, which keeps work on
+  the current branch — do NOT rely on it to branch for you. Branching is a
+  standing requirement regardless of that setting; if it is `none`, branch
+  manually before the first commit.
+- Merging branches into `main` is the user's call (typically via PR) — do not
+  fast-forward or merge to `main` without being asked.
+
 ## Changelog Maintenance
 
 - Update `CHANGELOG.md` phase-by-phase as work lands; do not defer to release-cut time

--- a/cement/ext/ext_argparse.py
+++ b/cement/ext/ext_argparse.py
@@ -392,6 +392,35 @@ class ArgparseController(ControllerHandler):
         meta: CommandMeta | None = getattr(member, '__cement_meta__', None)
         return meta
 
+    @property
+    def _default_command_meta(self) -> "CommandMeta | None":
+        """
+        Read-only accessor for this controller's default sub-command meta.
+
+        Companion to :attr:`_command_meta` for the default-function path.
+        Argparse has no native default sub-command, so Cement reaches the
+        default via ``Meta.default_func`` rather than the ``__dispatch__``
+        token that exposed commands flow through -- which is why
+        ``_command_meta`` is ``None`` while the default function runs.  This
+        accessor resolves the default function's ``CommandMeta`` directly so a
+        default command can still read its own ``@ex``/``@expose`` meta, e.g.
+        ``self._default_command_meta.parser_options['help']``.
+
+        Returns:
+            CommandMeta | None: The meta for the controller's default
+            sub-command, or ``None`` when ``Meta.default_func`` is ``None`` or
+            points to a function that is not an exposed (``@ex``/``@expose``)
+            command -- e.g. the framework's stock ``_default`` (``print_help``)
+            carries no meta.  Never raises.
+
+        """
+        func_name = _clean_func(self._meta.default_func)
+        if func_name is None:
+            return None
+        member = getattr(self.__class__, func_name, None)
+        meta: CommandMeta | None = getattr(member, '__cement_meta__', None)
+        return meta
+
     def _validate(self) -> None:
         try:
             assert self._meta.stacked_type in ['embedded', 'nested'], \

--- a/cement/ext/ext_argparse.py
+++ b/cement/ext/ext_argparse.py
@@ -382,9 +382,14 @@ class ArgparseController(ControllerHandler):
         if not hasattr(self.app.pargs, '__dispatch__'):
             return None
         func_name = self.app.pargs.__dispatch__.split('.')[1]
-        if not hasattr(self.__class__, func_name):
-            return None  # pragma: nocover  # defensive: unreachable
-        meta: CommandMeta = getattr(self.__class__, func_name).__cement_meta__
+        # Resolve the class-level command function and read its CommandMeta.
+        # Guarding on the __cement_meta__ marker (rather than mere attribute
+        # existence) keeps the never-raises contract: this property can also
+        # run on a non-owning controller (e.g. via _post_argument_parsing),
+        # whose class may carry a same-named, non-command attribute -- that
+        # yields None here instead of an AttributeError (WR-01).
+        member = getattr(self.__class__, func_name, None)
+        meta: CommandMeta | None = getattr(member, '__cement_meta__', None)
         return meta
 
     def _validate(self) -> None:

--- a/cement/ext/ext_argparse.py
+++ b/cement/ext/ext_argparse.py
@@ -348,6 +348,45 @@ class ArgparseController(ControllerHandler):
     def _default(self) -> None:
         self._parser.print_help()
 
+    @property
+    def _command_meta(self) -> "CommandMeta | None":
+        """
+        Read-only accessor for the currently-dispatched command's meta.
+
+        This centralizes the otherwise repetitive lookup of a command's own
+        ``CommandMeta`` (label, func_name, hide, arguments, and the
+        ``parser_options`` dict holding ``help``/``aliases``/etc.) so an
+        exposed command can read its own ``@ex``/``@expose`` decorator data
+        from inside its body, e.g.
+        ``self._command_meta.parser_options['help']``.
+
+        Note:
+            The returned object is the shared, class-level ``CommandMeta``
+            attached to the command function (its ``.controller`` field is
+            mutated to ``self`` during ``_collect_commands``).  It is not a
+            per-invocation copy; do not mutate it or stash per-call state on
+            it.
+
+        Returns:
+            CommandMeta | None: The meta for the running command, or ``None``
+            when accessed outside a dispatched command (no ``__dispatch__``
+            on ``self.app.pargs`` -- e.g. the default/no-sub-command path).
+
+        """
+        # FIXME: Cement 4 may introduce opt-in func-signature injection
+        # (e.g. ``def cmd(self, func_name, func_meta)``) as the ergonomic
+        # default.  That form is backward-incompatible for 3.0.x (it would
+        # change the released ``func()`` dispatch signature), so for now we
+        # ship this additive read-only accessor only and leave dispatch as
+        # ``return func()`` (see ``_dispatch`` below).
+        if not hasattr(self.app.pargs, '__dispatch__'):
+            return None
+        func_name = self.app.pargs.__dispatch__.split('.')[1]
+        if not hasattr(self.__class__, func_name):
+            return None  # pragma: nocover  # defensive: unreachable
+        meta: CommandMeta = getattr(self.__class__, func_name).__cement_meta__
+        return meta
+
     def _validate(self) -> None:
         try:
             assert self._meta.stacked_type in ['embedded', 'nested'], \
@@ -818,6 +857,10 @@ class ArgparseController(ControllerHandler):
         if hasattr(self.app.pargs, '__dispatch__'):
             # if __dispatch__ is set that means that we have hit a sub-command
             # of a controller.
+            #
+            # FIXME: dispatch stays ``return func()`` (additive-only, 3.0.x
+            # BC).  A command reads its own meta via ``self._command_meta``;
+            # opt-in func-signature injection is deferred to Cement 4.
             contr_label = self.app.pargs.__dispatch__.split('.')[0]
             func_name = self.app.pargs.__dispatch__.split('.')[1]
         else:

--- a/tests/ext/test_ext_argparse.py
+++ b/tests/ext/test_ext_argparse.py
@@ -303,6 +303,27 @@ def test_command_meta_none_outside_dispatch():
         assert res == "Inside Base.default : meta > None"
 
 
+def test_command_meta_non_owning_controller_returns_none():
+    # WR-01 hardening: _command_meta also runs on controllers that do NOT own
+    # the dispatched command (e.g. via _post_argument_parsing).  When such a
+    # controller's class carries a same-named, non-command attribute, the
+    # property must return None -- not raise AttributeError on __cement_meta__.
+    class Foreign(ArgparseController):
+        class Meta:
+            label = 'foreign'
+
+        # collides by name with Base.command_meta_cmd but is not an @expose
+        # command, so it has no __cement_meta__ marker
+        def command_meta_cmd(self):  # pragma: nocover - never invoked
+            return "not a cement command"
+
+    with ArgparseApp(argv=['command-meta-cmd']) as app:
+        app.run()
+        foreign = Foreign()
+        foreign.app = app
+        assert foreign._command_meta is None
+
+
 def test_controller_commands():
     with ArgparseApp(argv=['cmd2']) as app:
         res = app.run()

--- a/tests/ext/test_ext_argparse.py
+++ b/tests/ext/test_ext_argparse.py
@@ -28,11 +28,20 @@ class Base(ArgparseController):
 
     @expose(hide=True, help="this help doesn't get seen")
     def _default(self):
-        return "Inside Base.default"
+        # the no-sub-command path: __dispatch__ is not set on pargs, so the
+        # _command_meta accessor must return None here (D-03).
+        return f"Inside Base.default : meta > {self._command_meta}"
 
     @expose()
     def cmd1(self):
         return "Inside Base.cmd1"
+
+    @expose(help='help for command_meta_cmd')
+    def command_meta_cmd(self):
+        # the #670 ergonomic call site: a command reads its own @expose meta
+        # from inside its body via self._command_meta (D-01, D-02, D-04).
+        meta = self._command_meta
+        return f"{meta.label} : {meta.parser_options['help']}"
 
     @expose()
     def command_with_dashes(self):
@@ -262,7 +271,7 @@ def test_base_default():
 
     with ArgparseApp() as app:
         res = app.run()
-        assert res == "Inside Base.default"
+        assert res == "Inside Base.default : meta > None"
 
 
 def test_base_cmd1():
@@ -275,6 +284,23 @@ def test_base_command_with_dashes():
     with ArgparseApp(argv=['command-with-dashes']) as app:
         res = app.run()
         assert res == "Inside Base.command_with_dashes"
+
+
+def test_command_meta_dispatched():
+    # dispatched-command branch: the command reads its own CommandMeta from
+    # inside its body and returns its label + @expose(help=...) string (the
+    # #670 ergonomic call site, D-02/D-04).
+    with ArgparseApp(argv=['command-meta-cmd']) as app:
+        res = app.run()
+        assert res == "command-meta-cmd : help for command_meta_cmd"
+
+
+def test_command_meta_none_outside_dispatch():
+    # None branch (D-03): the default/no-sub-command path has no __dispatch__
+    # on pargs, so _command_meta returns None and does not raise.
+    with ArgparseApp() as app:
+        res = app.run()
+        assert res == "Inside Base.default : meta > None"
 
 
 def test_controller_commands():

--- a/tests/ext/test_ext_argparse.py
+++ b/tests/ext/test_ext_argparse.py
@@ -324,6 +324,38 @@ def test_command_meta_non_owning_controller_returns_none():
         assert foreign._command_meta is None
 
 
+def test_default_command_meta_decorated():
+    # _default_command_meta resolves the default sub-command's meta directly
+    # (no __dispatch__ needed).  Third._default is @expose(hide=True), so its
+    # CommandMeta is reachable.
+    meta = Third()._default_command_meta
+    assert meta is not None
+    assert meta.func_name == '_default'
+    assert meta.hide is True
+
+
+def test_default_command_meta_undecorated_returns_none():
+    # A controller using the framework's stock _default (print_help) -- which
+    # is NOT @expose-decorated and carries no __cement_meta__ -- yields None
+    # rather than raising AttributeError.
+    class PlainDefault(ArgparseController):
+        class Meta:
+            label = 'plaindefault'
+
+    assert PlainDefault()._default_command_meta is None
+
+
+def test_default_command_meta_none_default_func_returns_none():
+    # Meta.default_func = None ("pass and exit 0") -> _clean_func(None) is None
+    # -> the accessor returns None without touching getattr.
+    class NoDefault(ArgparseController):
+        class Meta:
+            label = 'nodefault'
+            default_func = None
+
+    assert NoDefault()._default_command_meta is None
+
+
 def test_controller_commands():
     with ArgparseApp(argv=['cmd2']) as app:
         res = app.run()


### PR DESCRIPTION
## Summary

Adds a single additive, read-only `_command_meta` property to
`ArgparseController`, resolving [#670](https://github.com/datafolklabs/cement/issues/670).
An exposed `@ex`/`@expose` command can now read its own `CommandMeta` from
inside its body via `self._command_meta` — e.g.
`self._command_meta.parser_options['help']` — instead of the brittle
`getattr(self, self.app.pargs.__dispatch__.split('.')[1]).__cement_meta__`
dance (which broke in the wild once `CommandMeta` became a dataclass).

The change is **purely additive and backward-compatible on the 3.0.x track**:
the released `func()` dispatch signature is untouched. The issue's literal
`func(func_name, func_meta)` injection proposal is intentionally **not** adopted
here — it would change the released dispatch signature and is deferred to
Cement 4 (recorded as a `# FIXME:` near the accessor and at `_dispatch`).

## Changes

**Accessor (feat)**
- New `ArgparseController._command_meta` `@property` returning
  `CommandMeta | None`. Derives the running command from
  `self.app.pargs.__dispatch__`, resolves the class-level `CommandMeta` via the
  function's `__cement_meta__` marker, and returns `None` outside a dispatched
  command. Never raises.

**Robustness hardening (fix — from code review)**
- The guard keys on the `__cement_meta__` marker
  (`getattr(member, '__cement_meta__', None)`) rather than bare attribute
  existence. This makes the documented "never raises" contract provably hold
  even when the property is read from a **non-owning** controller (e.g. via
  `_post_argument_parsing`) whose class happens to carry a same-named,
  non-command attribute — that path now returns `None` instead of raising
  `AttributeError`. The change also collapses both guard branches and removes a
  `# pragma: nocover` defensive line.

**Tests**
- `test_command_meta_dispatched` — command reads its own `@expose(help=...)`.
- `test_command_meta_none_outside_dispatch` — no-dispatch path returns `None`.
- `test_command_meta_non_owning_controller_returns_none` — non-owning
  controller returns `None` (never raises).

**Docs**
- `CHANGELOG.md`: `[ext.argparse]` Features entry referencing #670.
- `CLAUDE.md`: adds a **Branching Policy** section — never commit to `main`
  without explicit consent (planning artifacts included), and branch
  immediately when phase/task work begins rather than relying on GSD's
  `branching_strategy` config.

## Acceptance status

| Decision | Description | Status |
|----------|-------------|--------|
| D-01 | Read-only `_command_meta` property on `ArgparseController` | ✅ |
| D-02 | Returns `CommandMeta` for the running command from `pargs.__dispatch__` | ✅ |
| D-03 | Returns `None` (never raises) when no command is dispatched | ✅ |
| D-04 | Returns raw `CommandMeta` as-is (no wrapper/shortcuts) | ✅ |
| D-05 | Exposes only the currently-running command's meta | ✅ |
| D-06 | `func()` dispatch signature unchanged (no signature injection) | ✅ |
| D-07 | Cement 4 deferral comment near accessor and at `_dispatch` | ✅ |

Verified 5/5 must-have truths against the codebase (full report archived
post-merge with the phase planning artifacts).

## Files touched

| File | Change |
|------|--------|
| `cement/ext/ext_argparse.py` | New `_command_meta` property (additive, read-only) |
| `tests/ext/test_ext_argparse.py` | 3 tests: dispatched, None, non-owning-controller |
| `CHANGELOG.md` | `[ext.argparse]` Features entry (#670) |
| `CLAUDE.md` | New Branching Policy section |

## Test plan

- [x] `make comply` — ruff clean + mypy clean (51 source files)
- [x] `make test` — full suite **375 passed, 100.00% coverage**
      (Redis + memcached up); `ext_argparse.py` 318/318 stmts, 0 miss
- [x] Backward compatibility — single `return func()` at dispatch is unchanged;
      every existing `def cmd(self)` still receives zero extra positional args
- [x] New accessor never raises on the no-dispatch and non-owning-controller paths


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added read-only access for commands to retrieve their dispatched command metadata during execution.
  * Added read-only access for the default/no-subcommand path to retrieve default command metadata when available.
* **Documentation**
  * Updated changelog entries and added branching policy guidance.
* **Tests**
  * Expanded coverage for dispatched vs non-dispatched behavior, controller ownership edge cases, and default command metadata scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->