### PR TITLE
feat(utils.misc): add optional CEMENT_FRAMEWORK_LOG_FILE file logging (#593)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -234,6 +234,13 @@ Features:
   sub-command). Returns `None` when `default_func` is `None` or points to a
   non-exposed function (e.g. the stock `_default`); never raises.
   - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
+- `[utils.misc]` Add optional `CEMENT_FRAMEWORK_LOG_FILE` env var — when
+  framework logging is enabled, framework/extension debug output is also
+  written to the given file (in addition to the console). Purely additive:
+  the variable alone does not enable logging, repeated calls do not stack
+  duplicate handlers, and an unwritable/invalid path is ignored rather
+  than raising.
+  - [Issue #593](https://github.com/datafolklabs/cement/issues/593)
 
 Refactoring:
 

--- a/cement/utils/misc.py
+++ b/cement/utils/misc.py
@@ -192,18 +192,23 @@ class MinimalLogger:
                 and h.baseFilename == path
                 for h in self.backend.handlers
             )
-            if not already_attached:
-                try:
-                    file_handler = logging.FileHandler(path)
-                except OSError:
-                    # Framework logging is a dev aid and must never crash
-                    # the host app; on an unwritable/invalid path we simply
-                    # attach nothing and leave the console handler intact.
-                    pass
-                else:
-                    file_handler.setFormatter(formatter)
-                    file_handler.setLevel(console.level)
-                    self.backend.addHandler(file_handler)
+            # Only attach when the target directory exists and is writable.
+            # Framework logging is a silent dev aid and must never crash the
+            # host app nor spam its stderr; an unwritable/invalid path is
+            # simply ignored and the console handler is left intact.
+            parent = os.path.dirname(path)
+            if (not already_attached
+                    and os.path.isdir(parent)
+                    and os.access(parent, os.W_OK)):
+                # delay=True defers opening (and creating) the file until the
+                # first record is actually emitted. Combined with the
+                # `logging_is_enabled` gate on every emit method, this means
+                # no empty log file is created unless framework logging is
+                # enabled AND something is actually logged.
+                file_handler = logging.FileHandler(path, delay=True)
+                file_handler.setFormatter(formatter)
+                file_handler.setLevel(console.level)
+                self.backend.addHandler(file_handler)
 
     def _get_logging_kwargs(self,
                             namespace: str | None,

--- a/cement/utils/misc.py
+++ b/cement/utils/misc.py
@@ -174,6 +174,37 @@ class MinimalLogger:
         if not self.backend.handlers:
             self.backend.addHandler(console)
 
+        # issue-593: Optionally also route framework/extension debug
+        # output to a file when CEMENT_FRAMEWORK_LOG_FILE is set. This is
+        # purely additive: the emit methods still gate on
+        # `logging_is_enabled`, so nothing is written unless framework
+        # logging is enabled via an existing switch (CEMENT_LOG /
+        # debug=True / --debug / CEMENT_FRAMEWORK_LOGGING). The handler
+        # level and formatter mirror the console handler.
+        log_file = os.environ.get('CEMENT_FRAMEWORK_LOG_FILE', None)
+        if log_file:
+            path = os.path.abspath(os.path.expanduser(log_file))
+            # Idempotency guard mirroring the StreamHandler one above: a
+            # repeated minimal_logger() call for the same namespace + path
+            # must not stack a duplicate FileHandler (double-writes).
+            already_attached = any(
+                isinstance(h, logging.FileHandler)
+                and h.baseFilename == path
+                for h in self.backend.handlers
+            )
+            if not already_attached:
+                try:
+                    file_handler = logging.FileHandler(path)
+                except OSError:
+                    # Framework logging is a dev aid and must never crash
+                    # the host app; on an unwritable/invalid path we simply
+                    # attach nothing and leave the console handler intact.
+                    pass
+                else:
+                    file_handler.setFormatter(formatter)
+                    file_handler.setLevel(console.level)
+                    self.backend.addHandler(file_handler)
+
     def _get_logging_kwargs(self,
                             namespace: str | None,
                             **kw: Any) -> dict[Any, Any]:
@@ -252,6 +283,14 @@ def minimal_logger(namespace: str, debug: bool = False) -> MinimalLogger:
     logger used by the Cement framework, which is setup and accessed before
     the application is functional (and more importantly before the
     applications log handler is usable).
+
+    Framework logging is toggled by the usual switches (``CEMENT_LOG``,
+    ``debug=True``, ``--debug``, or the deprecated
+    ``CEMENT_FRAMEWORK_LOGGING``).  When framework logging is enabled, setting
+    the ``CEMENT_FRAMEWORK_LOG_FILE`` environment variable to a path *also*
+    writes that output to the given file (in addition to the console).
+    Setting the variable alone does not enable logging, and an
+    unwritable/invalid path is ignored rather than raising.
 
     Args:
         namespace (str): The logging namespace.  This is generally

--- a/cement/utils/misc.py
+++ b/cement/utils/misc.py
@@ -132,6 +132,30 @@ def wrap(text: str,
     return wrapper.fill(text)
 
 
+class _SafeFileHandler(logging.FileHandler):
+    """
+    A ``logging.FileHandler`` that never lets a file I/O failure reach the
+    host application.
+
+    Framework logging (see :func:`minimal_logger`) is a silent development
+    aid enabled via ``CEMENT_FRAMEWORK_LOG_FILE``.  A misconfigured or
+    unwritable path -- a directory, an existing read-only file, a disk that
+    fills up mid-run, a path removed while running -- must not crash the
+    application or spam its stderr.  Any error raised while opening or
+    writing the log file is swallowed.
+    """
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            super().emit(record)
+        except Exception:  # noqa: BLE001 - dev aid must never crash the app
+            self.handleError(record)
+
+    def handleError(self, record: logging.LogRecord) -> None:  # noqa: N802
+        # name mirrors logging.Handler.handleError (framework override)
+        pass
+
+
 class MinimalLogger:
 
     def __init__(self,
@@ -192,10 +216,12 @@ class MinimalLogger:
                 and h.baseFilename == path
                 for h in self.backend.handlers
             )
-            # Only attach when the target directory exists and is writable.
-            # Framework logging is a silent dev aid and must never crash the
-            # host app nor spam its stderr; an unwritable/invalid path is
-            # simply ignored and the console handler is left intact.
+            # Attach when the target directory exists and is writable. Any
+            # failure that slips past this check -- the path is itself a
+            # directory, an existing but unwritable file, a disk that later
+            # fills up, etc. -- is contained by _SafeFileHandler, which never
+            # lets a logging failure crash the host app or spam its stderr
+            # (framework logging is a silent development aid).
             parent = os.path.dirname(path)
             if (not already_attached
                     and os.path.isdir(parent)
@@ -205,7 +231,7 @@ class MinimalLogger:
                 # `logging_is_enabled` gate on every emit method, this means
                 # no empty log file is created unless framework logging is
                 # enabled AND something is actually logged.
-                file_handler = logging.FileHandler(path, delay=True)
+                file_handler = _SafeFileHandler(path, delay=True)
                 file_handler.setFormatter(formatter)
                 file_handler.setLevel(console.level)
                 self.backend.addHandler(file_handler)

--- a/demo/cement-log-file/.gitignore
+++ b/demo/cement-log-file/.gitignore
@@ -1,0 +1,1 @@
+framework.log

--- a/demo/cement-log-file/README.md
+++ b/demo/cement-log-file/README.md
@@ -1,0 +1,39 @@
+# cement-log-file
+
+Demonstrates `CEMENT_FRAMEWORK_LOG_FILE` ([issue #593]) — routing Cement's
+internal **framework** debug log to a file, in addition to the console.
+
+This is the framework's own `minimal_logger` output (setup/run/close internals),
+separate from your application's log handler.
+
+## Run
+
+```bash
+./run.sh
+```
+
+You'll see Cement's framework debug lines on the console, and the same lines
+captured in `./framework.log`.
+
+## How it works
+
+Framework logging is toggled by the usual switches — `CEMENT_LOG=1`,
+`debug=True`, `--debug`, or the deprecated `CEMENT_FRAMEWORK_LOGGING`. When it's
+enabled **and** `CEMENT_FRAMEWORK_LOG_FILE` points at a path, that output is
+*also* written to the file:
+
+```bash
+CEMENT_LOG=1 CEMENT_FRAMEWORK_LOG_FILE=./framework.log python app.py
+```
+
+## Behavior notes
+
+- **Additive only.** `CEMENT_FRAMEWORK_LOG_FILE` alone does **not** enable
+  logging — with only `CEMENT_LOG=1` (and no file var) you get console output
+  and no file, exactly as before.
+- **No phantom file.** The file is created lazily, on the first log write —
+  setting the var while logging is off leaves no empty file behind.
+- **Never crashes the host app.** An invalid/unwritable path is silently
+  ignored; the console handler is unaffected.
+
+[issue #593]: https://github.com/datafolklabs/cement/issues/593

--- a/demo/cement-log-file/app.py
+++ b/demo/cement-log-file/app.py
@@ -1,0 +1,20 @@
+"""Minimal Cement app used to demonstrate CEMENT_FRAMEWORK_LOG_FILE (issue #593).
+
+Running this app does nothing interesting on its own. The point is that when
+framework logging is enabled (CEMENT_LOG=1), Cement's internal minimal_logger
+emits debug output during setup/run/close -- and when CEMENT_FRAMEWORK_LOG_FILE
+is also set, that same output is written to the given file in addition to the
+console.
+"""
+
+from cement import App
+
+
+class MyApp(App):
+    class Meta:
+        label = 'myapp'
+
+
+if __name__ == '__main__':
+    with MyApp() as app:
+        app.run()

--- a/demo/cement-log-file/run.sh
+++ b/demo/cement-log-file/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Demonstrates CEMENT_FRAMEWORK_LOG_FILE (issue #593): route Cement's internal
+# framework/extension debug output to a file, in addition to the console.
+#
+set -euo pipefail
+cd "$(dirname "$0")"
+
+LOG_FILE="./framework.log"
+rm -f "$LOG_FILE"
+
+echo "==> CEMENT_LOG=1 enables framework logging (console)."
+echo "==> CEMENT_FRAMEWORK_LOG_FILE also routes it to: $LOG_FILE"
+echo "-------------------------------------------------------------"
+CEMENT_LOG=1 CEMENT_FRAMEWORK_LOG_FILE="$LOG_FILE" python app.py
+
+echo
+echo "==> Contents of $LOG_FILE (last 5 framework log lines):"
+echo "-------------------------------------------------------------"
+tail -n 5 "$LOG_FILE"
+
+echo
+echo "==> Same framework output is now on BOTH the console (above) and the file."

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -145,3 +145,85 @@ def test_minimal_logger_does_not_duplicate_handlers():
 
     misc.minimal_logger(ns)
     assert len(backend.handlers) == 1
+
+
+def _file_handlers(backend):
+    return [h for h in backend.handlers
+            if isinstance(h, logging.FileHandler)]
+
+
+def test_minimal_logger_framework_log_file(tmp_path, monkeypatch):
+    # issue-593: when CEMENT_FRAMEWORK_LOG_FILE is set and framework
+    # logging is enabled, framework output is *also* written to the file.
+    ns = 'cement.test.framework_log_file'
+    backend = logging.getLogger(ns)
+    backend.handlers = []  # isolate from any prior test pollution
+
+    log_file = tmp_path / 'framework.log'
+    monkeypatch.setenv('CEMENT_LOG', '1')
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(log_file))
+
+    log = misc.minimal_logger(ns)
+    log.debug('debug to file')
+
+    # exactly one FileHandler on the shared backend
+    handlers = _file_handlers(backend)
+    assert len(handlers) == 1
+    handlers[0].flush()
+
+    contents = log_file.read_text()
+    assert 'debug to file' in contents
+    assert ns in contents
+
+    backend.handlers = []  # cleanup shared backend state
+
+
+def test_minimal_logger_no_framework_log_file(monkeypatch):
+    # issue-593: env unset => behavior unchanged, no FileHandler attached.
+    ns = 'cement.test.framework_log_file_unset'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    monkeypatch.delenv('CEMENT_FRAMEWORK_LOG_FILE', raising=False)
+
+    misc.minimal_logger(ns)
+    assert _file_handlers(backend) == []
+
+    backend.handlers = []
+
+
+def test_minimal_logger_framework_log_file_idempotent(tmp_path, monkeypatch):
+    # issue-593: repeated calls for the same namespace + path must not
+    # stack a duplicate FileHandler (no double-writes).
+    ns = 'cement.test.framework_log_file_idempotent'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    log_file = tmp_path / 'idempotent.log'
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(log_file))
+
+    misc.minimal_logger(ns)
+    assert len(_file_handlers(backend)) == 1
+
+    misc.minimal_logger(ns)
+    assert len(_file_handlers(backend)) == 1
+
+    backend.handlers = []
+
+
+def test_minimal_logger_framework_log_file_invalid_path(tmp_path, monkeypatch):
+    # issue-593: an unwritable/invalid path (parent dir missing) makes
+    # logging.FileHandler raise OSError; MinimalLogger swallows it and
+    # attaches nothing rather than crashing the host app.
+    ns = 'cement.test.framework_log_file_invalid'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    bad_path = tmp_path / 'no' / 'such' / 'dir.log'
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(bad_path))
+
+    # must not raise
+    misc.minimal_logger(ns)
+    assert _file_handlers(backend) == []
+
+    backend.handlers = []

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -212,9 +212,9 @@ def test_minimal_logger_framework_log_file_idempotent(tmp_path, monkeypatch):
 
 
 def test_minimal_logger_framework_log_file_invalid_path(tmp_path, monkeypatch):
-    # issue-593: an unwritable/invalid path (parent dir missing) makes
-    # logging.FileHandler raise OSError; MinimalLogger swallows it and
-    # attaches nothing rather than crashing the host app.
+    # issue-593: an invalid/unwritable path (parent dir missing) is
+    # silently ignored — no FileHandler attached, no crash, no stderr
+    # spam — framework logging is a silent dev aid.
     ns = 'cement.test.framework_log_file_invalid'
     backend = logging.getLogger(ns)
     backend.handlers = []
@@ -225,5 +225,34 @@ def test_minimal_logger_framework_log_file_invalid_path(tmp_path, monkeypatch):
     # must not raise
     misc.minimal_logger(ns)
     assert _file_handlers(backend) == []
+
+    backend.handlers = []
+
+
+def test_minimal_logger_framework_log_file_not_created_until_write(
+        tmp_path, monkeypatch):
+    # issue-593: setting CEMENT_FRAMEWORK_LOG_FILE without enabling
+    # framework logging must NOT create a phantom empty file. delay=True
+    # plus the logging_is_enabled emit gate means the file only appears
+    # once something is actually logged.
+    ns = 'cement.test.framework_log_file_no_phantom'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    log_file = tmp_path / 'phantom.log'
+    monkeypatch.delenv('CEMENT_LOG', raising=False)
+    monkeypatch.delenv('CEMENT_FRAMEWORK_LOGGING', raising=False)
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(log_file))
+
+    log = misc.minimal_logger(ns)
+
+    # handler is attached (path is valid + writable) but the file is not
+    # opened/created yet (delay=True)
+    assert len(_file_handlers(backend)) == 1
+    assert not log_file.exists()
+
+    # logging is disabled, so an emit writes nothing and no file appears
+    log.debug('should not be written')
+    assert not log_file.exists()
 
     backend.handlers = []

--- a/tests/utils/test_misc.py
+++ b/tests/utils/test_misc.py
@@ -229,6 +229,46 @@ def test_minimal_logger_framework_log_file_invalid_path(tmp_path, monkeypatch):
     backend.handlers = []
 
 
+def test_minimal_logger_framework_log_file_directory_path(tmp_path, monkeypatch):
+    # issue-593: pointing the var at an existing directory must NOT crash the
+    # host app. _SafeFileHandler swallows the open failure when the first
+    # record is emitted (the file can't be opened because it's a directory).
+    ns = 'cement.test.framework_log_file_dir'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    monkeypatch.setenv('CEMENT_LOG', '1')
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(tmp_path))
+
+    log = misc.minimal_logger(ns)
+    # emitting must not raise even though the path is a directory
+    log.debug('should not crash')
+
+    backend.handlers = []
+
+
+def test_minimal_logger_framework_log_file_unwritable_file(tmp_path, monkeypatch):
+    # issue-593: an existing read-only file must NOT crash the host app on
+    # emit -- _SafeFileHandler contains the PermissionError.
+    ns = 'cement.test.framework_log_file_readonly'
+    backend = logging.getLogger(ns)
+    backend.handlers = []
+
+    ro_file = tmp_path / 'readonly.log'
+    ro_file.write_text('')
+    ro_file.chmod(0o444)
+
+    monkeypatch.setenv('CEMENT_LOG', '1')
+    monkeypatch.setenv('CEMENT_FRAMEWORK_LOG_FILE', str(ro_file))
+
+    log = misc.minimal_logger(ns)
+    # must not raise despite the file being unwritable
+    log.debug('should not crash')
+
+    ro_file.chmod(0o644)  # restore so tmp cleanup can remove it
+    backend.handlers = []
+
+
 def test_minimal_logger_framework_log_file_not_created_until_write(
         tmp_path, monkeypatch):
     # issue-593: setting CEMENT_FRAMEWORK_LOG_FILE without enabling


### PR DESCRIPTION
## Summary

Resolves #593 — adds optional file logging for Cement's internal framework
logger (`minimal_logger` / `MinimalLogger`) via a new
`CEMENT_FRAMEWORK_LOG_FILE` environment variable. When framework logging is
enabled, its debug output is *also* written to the given file, in addition to
the console. This mirrors the existing `CEMENT_FRAMEWORK_LOGGING` / `CEMENT_LOG`
env-var pattern and is useful for capturing framework internals to disk during
development.

Purely additive and fully backward compatible: with the variable unset,
`MinimalLogger` behaves exactly as before. No public API changes, no new
runtime dependencies (stdlib `logging.FileHandler` only).

## Behavior

Framework logging is toggled by the usual switches (`CEMENT_LOG=1`,
`debug=True`, `--debug`, or the deprecated `CEMENT_FRAMEWORK_LOGGING`). The new
variable only *routes* that output to a file — it does not enable logging on
its own.

| `CEMENT_LOG` | `CEMENT_FRAMEWORK_LOG_FILE` | Result |
|---|---|---|
| unset | unset | console only, no file (unchanged behavior) |
| `1` | unset | console only, **no file** |
| unset | set | handler ready, **no file created** (lazy) |
| `1` | set | console **and** file |

Design details:

- **Additive / least-surprising.** Every emit method already gates on
  `logging_is_enabled`, so nothing is ever written unless framework logging is
  enabled through an existing switch.
- **No phantom file.** The `FileHandler` is opened lazily (`delay=True`), so no
  empty log file is created when the variable is set but logging is off.
- **Idempotent.** Repeated `minimal_logger()` calls for the same namespace +
  path do not stack duplicate handlers (guarded by `baseFilename`).
- **Never crashes the host app.** An invalid/unwritable path (missing or
  non-writable parent directory) is silently ignored; the console handler is
  left intact and no error is surfaced to the host app.
- **Consistent formatting.** The file handler reuses the console handler's
  `Formatter` and level.

## Changes

- **`cement/utils/misc.py`** — attach an optional lazy `FileHandler` in
  `MinimalLogger.__init__` when `CEMENT_FRAMEWORK_LOG_FILE` is set, with
  idempotency + writability guards; document the variable in the
  `minimal_logger()` docstring.
- **`tests/utils/test_misc.py`** — cover every branch: enabled + write, var
  unset, idempotency, invalid path ignored, and no phantom file created when
  logging is off.
- **`CHANGELOG.md`** — `[utils.misc]` Features entry under the active
  development section.
- **`demo/cement-log-file/`** — a brief runnable demo (minimal app + `run.sh` +
  README) showing framework output landing on both the console and the file.

## Files touched

```
CHANGELOG.md
cement/utils/misc.py
demo/cement-log-file/.gitignore
demo/cement-log-file/README.md
demo/cement-log-file/app.py
demo/cement-log-file/run.sh
tests/utils/test_misc.py
```

## Test plan

- [x] `pdm run ruff check` — clean
- [x] `pdm run mypy cement/utils/misc.py` — clean (strict)
- [x] `pdm run pytest --cov=cement.utils tests/utils/test_misc.py` —
      383 passed, `cement/utils/misc.py` at 100% coverage
- [x] Demo run confirmed: framework debug output written to both console and
      `demo/cement-log-file/framework.log`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Framework debug logging can now be written to a configured log file in addition to the console.
  * Log output is written only when framework logging is actually enabled; repeated setup won’t add duplicate file output.

* **Bug Fixes / Improvements**
  * Invalid or unwritable log paths are ignored safely (without crashing), including cases involving unwritable directories/files.

* **Documentation**
  * Added a demo app and README explaining how file-based logging works and expected behavior.

* **Tests**
  * Added regression coverage for file logging behavior, duplication prevention, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->