### PR TITLE
ci: fix release preflight/dev-bump pylibmc install failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,12 @@ jobs:
         uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.x"
-      - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4.5
-      - name: Install dependencies
-        run: pdm install
+      # NOT `pdm install`: the lock's all-extras selection builds pylibmc,
+      # which needs libmemcached headers this job doesn't have (and shouldn't
+      # need). cement core is zero-dependency — a plain pip install of the
+      # checkout is everything get_version() requires.
+      - name: Install cement (zero-dep core)
+        run: python -m pip install .
       # `github.ref_name` is passed via env, never spliced into script text:
       # on dispatch it is an arbitrary branch name (shell-metacharacter-capable),
       # and inline `${{ }}` expansion would be a template-injection vector.
@@ -57,7 +59,7 @@ jobs:
           set -euo pipefail
           TAG="$TAG_REF"                                     # e.g. 3.0.16 (branch name on dispatch)
           # Package version is the single source of truth (cement.utils.version:get_version).
-          PKG=$(pdm run python -c "from cement.utils.version import get_version; print(get_version())")
+          PKG=$(python -c "from cement.utils.version import get_version; print(get_version())")
           if [ "$EVENT" = "push" ]; then
             [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "::error::tag '$TAG' not strict semver"; exit 1; }
             [ "$TAG" = "$PKG" ] || { echo "::error::tag $TAG != package version $PKG"; exit 1; }
@@ -325,10 +327,9 @@ jobs:
         uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.x"
-      - name: Setup PDM
-        uses: pdm-project/setup-pdm@v4.5
-      - name: Install dependencies
-        run: pdm install
+      # No dependency install: bump_dev_version.py is pure stdlib — the full
+      # `pdm install` here would rebuild pylibmc without libmemcached headers
+      # (the same failure preflight had) for zero benefit.
       - name: Compute next dev version
         id: next
         env:
@@ -339,7 +340,7 @@ jobs:
       - name: Bump VERSION + open dev changelog
         env:
           NEXT: ${{ steps.next.outputs.version }}
-        run: pdm run python scripts/bump_dev_version.py "$NEXT"
+        run: python scripts/bump_dev_version.py "$NEXT"
       - name: Open dev-bump PR
         uses: peter-evans/create-pull-request@v8.1.1
         with:


### PR DESCRIPTION
## Summary

The first `release.yml` dispatch dry-run (run [29210275128](https://github.com/datafolklabs/cement/actions/runs/29210275128)) failed in `preflight`: bare `pdm install` resolves the lockfile's all-extras selection and builds `pylibmc`, but unlike the gate jobs, `preflight` never apt-installs `libmemcached-dev` — `fatal error: libmemcached/memcached.h: No such file`.

- **preflight** only needs `get_version()` from the zero-dependency core → plain `python -m pip install .`
- **dev-bump** had the identical latent failure waiting for release day, and `bump_dev_version.py` is pure stdlib → dependency install dropped entirely

Verified locally: `pip install .` in a clean venv exposes `get_version()` → `3.0.15`. No other `pdm install` remains in `release.yml` (the gate jobs that use it apt-install libmemcached first).

## Test plan

- [ ] Merge, re-dispatch: `gh workflow run release.yml -R datafolklabs/cement` → green through `dry-run-summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the release process by reducing setup steps during pre-release checks.
  * Simplified automatic development-version updates after releases.
  * Kept existing release workflow behavior and pipeline integration intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->