### PR TITLE
fix: testpypi-smoke app must not inherit the script's argv

### DIFF
--- a/scripts/testpypi-smoke.py
+++ b/scripts/testpypi-smoke.py
@@ -88,6 +88,11 @@ def main(argv: list[str]) -> int:
         class Meta:
             label = "smoke"
             exit_on_close = False
+            # Do NOT inherit this wrapper script's sys.argv — App.run() parses
+            # argv[1:] by default, and the version argument passed to THIS
+            # script ('3.0.15') would be rejected by the app's argparse
+            # ("unrecognized arguments").
+            argv: list[str] = []
 
     with SmokeApp() as app:
         app.run()

--- a/scripts/testpypi-smoke.py
+++ b/scripts/testpypi-smoke.py
@@ -37,6 +37,7 @@ from __future__ import annotations  # script-internal; doesn't affect cement/
 import subprocess
 import sys
 import time
+from typing import ClassVar
 
 # Per-attempt pip timeout (seconds): fail fast instead of hanging until the
 # GitHub Actions job-level timeout on a stalled network / unresponsive index.
@@ -92,7 +93,7 @@ def main(argv: list[str]) -> int:
             # argv[1:] by default, and the version argument passed to THIS
             # script ('3.0.15') would be rejected by the app's argparse
             # ("unrecognized arguments").
-            argv: list[str] = []
+            argv: ClassVar[list[str]] = []
 
     with SmokeApp() as app:
         app.run()


### PR DESCRIPTION
## Summary

Dry-run [29210928341](https://github.com/datafolklabs/cement/actions/runs/29210928341) made it further than ever — preflight ✓, full gates ✓, isolated build ✓, and the **first successful OIDC TestPyPI publish** (fresh wheel+sdist with attestations) — then failed in `testpypi-smoke`:

```
smoke: error: unrecognized arguments: 3.0.15
```

`App.run()` parses `sys.argv[1:]` by default, so the smoke app's argparse saw (and correctly rejected) the version argument passed to the wrapper script itself. One-line fix: `Meta.argv = []` on the smoke app.

**Verified end-to-end locally**: a fresh venv running the fixed script against real TestPyPI installs the exact `cement-3.0.15` bytes published by that run and passes the import/round-trip/version assertions:

```
TestPyPI smoke OK: cement 3.0.15 on Python 3.14.3
```

## Test plan

- [ ] Merge, re-dispatch: `gh workflow run release.yml -R datafolklabs/cement` → green through `dry-run-summary`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TestPyPI smoke testing by preventing unrelated command-line arguments from being passed to the application.
  * Existing installation, import, and version validation behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->