### PR TITLE
chore(release): finalize changelog and bump version to 3.0.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ __pypackages__
 
 # Claude Code agent worktrees (harness-internal scratch)
 .claude/worktrees/
+scratchpad/

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -349,11 +349,11 @@ Plans:
   4. The `3.0.16` git tag exists, the GitHub release page is published with the changelog body, and `pip install cement==3.0.16` from PyPI succeeds on a clean venv
   5. The release workflow itself (not just the artifacts) ran end-to-end without manual intervention beyond the user-approved publish step
 
-**Plans**: 5 plans across 5 waves (strictly sequential — provisioning-first is locked by D-09, and each stage gates the next: merged release-prep commit → final dry-run → human tag push + live run → post-release verification)
+**Plans**: 1/5 plans executed
 
   **Wave 1**
 
-  - [ ] 06-01-PLAN.md — Provisioning checkpoint: close Docker secrets (D-11) + confirm PyPI/RTD/release-env + one-time stable/3.0.x `-s ours` ancestry merge (D-09, D-10)
+  - [x] 06-01-PLAN.md — Provisioning checkpoint: close Docker secrets (D-11) + confirm PyPI/RTD/release-env + one-time stable/3.0.x `-s ours` ancestry merge (D-09, D-10)
 
   **Wave 2** *(blocked on Wave 1)*
 
@@ -388,7 +388,7 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6, with inserted 
 | 05.2. ext.argparse command self-meta accessor (INSERTED) | 1/1 | Complete   | 2026-06-25 |
 | 05.3. Template packaging modernization + typed templates (INSERTED) | 6/6 | Complete   | 2026-07-11 |
 | 05.4. GitHub Actions Release Workflow (INSERTED) | 5/5 | Complete    | 2026-07-12 |
-| 6. Release Cut 3.0.16 | 0/5 | Planned | - |
+| 6. Release Cut 3.0.16 | 1/5 | In Progress|  |
 
 ## Backlog
 

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -349,7 +349,27 @@ Plans:
   4. The `3.0.16` git tag exists, the GitHub release page is published with the changelog body, and `pip install cement==3.0.16` from PyPI succeeds on a clean venv
   5. The release workflow itself (not just the artifacts) ran end-to-end without manual intervention beyond the user-approved publish step
 
-**Plans**: TBD
+**Plans**: 5 plans across 5 waves (strictly sequential — provisioning-first is locked by D-09, and each stage gates the next: merged release-prep commit → final dry-run → human tag push + live run → post-release verification)
+
+  **Wave 1**
+
+  - [ ] 06-01-PLAN.md — Provisioning checkpoint: close Docker secrets (D-11) + confirm PyPI/RTD/release-env + one-time stable/3.0.x `-s ours` ancestry merge (D-09, D-10)
+
+  **Wave 2** *(blocked on Wave 1)*
+
+  - [ ] 06-02-PLAN.md — Release-prep PR: finalize CHANGELOG to `## 3.0.16` (D-01..D-04) + bump backend.py VERSION to 3.0.16 (REL-01); user reviews + merges (D-05)
+
+  **Wave 3** *(blocked on Wave 2)*
+
+  - [ ] 06-03-PLAN.md — Final `workflow_dispatch` dry-run against the merged 3.0.16 commit; 5-Python TestPyPI smoke green (D-06, CI-04, REL-02)
+
+  **Wave 4** *(blocked on Waves 1 + 3)*
+
+  - [ ] 06-04-PLAN.md — Pre-tag safety + USER tag push (D-07) + shepherd live run through the single approval gate; tag + GitHub Release published (D-08, REL-03)
+
+  **Wave 5** *(blocked on Wave 4)*
+
+  - [ ] 06-05-PLAN.md — REL-04 clean-venv PyPI check (D-13) + merge dev-bump PR to 3.0.17 (REL-05, D-12) + announcement draft (D-14) + 06-VERIFICATION.md flipping REL-01..05/CI-04/DOCS-03
 
 ## Progress
 
@@ -368,7 +388,7 @@ Phases execute in numeric order: 1 → 2 → 3 → 4 → 5 → 6, with inserted 
 | 05.2. ext.argparse command self-meta accessor (INSERTED) | 1/1 | Complete   | 2026-06-25 |
 | 05.3. Template packaging modernization + typed templates (INSERTED) | 6/6 | Complete   | 2026-07-11 |
 | 05.4. GitHub Actions Release Workflow (INSERTED) | 5/5 | Complete    | 2026-07-12 |
-| 6. Release Cut 3.0.16 | 0/TBD | Not started | - |
+| 6. Release Cut 3.0.16 | 0/5 | Planned | - |
 
 ## Backlog
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -2,17 +2,17 @@
 gsd_state_version: 1.0
 milestone: v1.0
 milestone_name: milestone
-current_phase: 6
-current_phase_name: Release Cut 3.0.16
+current_phase: 06
+current_phase_name: release-cut-3-0-16
 status: executing
 stopped_at: Phase 6 context gathered
-last_updated: "2026-07-13T00:28:55.597Z"
-last_activity: 2026-07-12
-last_activity_desc: Phase 05.4 complete, transitioned to Phase 6
+last_updated: "2026-07-13T14:16:59.051Z"
+last_activity: 2026-07-13
+last_activity_desc: Phase 06 execution started
 progress:
   total_phases: 11
   completed_phases: 9
-  total_plans: 45
+  total_plans: 50
   completed_plans: 45
   percent: 82
 ---
@@ -24,14 +24,14 @@ progress:
 See: .planning/PROJECT.md (updated 2026-07-12)
 
 **Core value:** Cement 3 stays solid, secure, performant, and bug-free under strict backward compatibility — while being continuously maintained against a modern Python and tooling ecosystem.
-**Current focus:** Phase 05.4 — github-actions-release-workflow
+**Current focus:** Phase 06 — release-cut-3-0-16
 
 ## Current Position
 
-Phase: 6 — Release Cut 3.0.16
-Plan: Not started
-Status: Executing — plan 05 at provisioning/dry-run checkpoint (4/5 plans complete)
-Last activity: 2026-07-12 — Phase 05.4 complete, transitioned to Phase 6
+Phase: 06 (release-cut-3-0-16) — EXECUTING
+Plan: 1 of 5
+Status: Executing Phase 06
+Last activity: 2026-07-13 — Phase 06 execution started
 
 Progress: [███████████████████░] 44/45 plans (98%) — 9/11 phases complete (Phase 05.4 in progress, Phase 6 release-cut remaining)
 

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -5,8 +5,8 @@ milestone_name: milestone
 current_phase: 6
 current_phase_name: Release Cut 3.0.16
 status: executing
-stopped_at: Phase 05.4 context gathered
-last_updated: "2026-07-12T23:20:05.052Z"
+stopped_at: Phase 6 context gathered
+last_updated: "2026-07-13T00:28:55.597Z"
 last_activity: 2026-07-12
 last_activity_desc: Phase 05.4 complete, transitioned to Phase 6
 progress:
@@ -205,6 +205,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-07-12T17:24:58.299Z
-Stopped at: Phase 05.4 context gathered
-Resume file: .planning/phases/05.4-github-actions-release-workflow/05.4-CONTEXT.md
+Last session: 2026-07-13T00:28:55.578Z
+Stopped at: Phase 6 context gathered
+Resume file: .planning/phases/06-release-cut-3-0-16/06-CONTEXT.md

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -6,14 +6,14 @@ current_phase: 06
 current_phase_name: release-cut-3-0-16
 status: executing
 stopped_at: Phase 6 context gathered
-last_updated: "2026-07-13T14:16:59.051Z"
+last_updated: "2026-07-13T14:50:33.911Z"
 last_activity: 2026-07-13
 last_activity_desc: Phase 06 execution started
 progress:
   total_phases: 11
   completed_phases: 9
   total_plans: 50
-  completed_plans: 45
+  completed_plans: 46
   percent: 82
 ---
 
@@ -29,8 +29,8 @@ See: .planning/PROJECT.md (updated 2026-07-12)
 ## Current Position
 
 Phase: 06 (release-cut-3-0-16) — EXECUTING
-Plan: 1 of 5
-Status: Executing Phase 06
+Plan: 2 of 5
+Status: Ready to execute
 Last activity: 2026-07-13 — Phase 06 execution started
 
 Progress: [███████████████████░] 44/45 plans (98%) — 9/11 phases complete (Phase 05.4 in progress, Phase 6 release-cut remaining)
@@ -88,6 +88,7 @@ Progress: [███████████████████░] 44/45 p
 | Phase 05.4 P01 | 6 min | 3 tasks | 3 files |
 | Phase 05.4 P02 | 2 min | 2 tasks | 2 files |
 | Phase 05.4 P04 | 5 min | 2 tasks | 1 files |
+| Phase 06-release-cut-3-0-16 P01 | ~35min | 3 tasks | 2 files |
 
 ## Accumulated Context
 
@@ -169,6 +170,7 @@ Recent decisions affecting current work:
 - [Phase 05.4]: [Phase 05.4 Plan 01]: dev scripts print by design; T201 suppressed with local # noqa rather than editing shared ruff config. ruff include filters scripts/ so directory-mode ruff check scripts/ passes but is not a real gate — later waves must pin explicit per-file paths.
 - [Phase 05.4]: [Phase 05.4 Plan 01]: cli-smoke-native banner accepts macOS plus Linux/Darwin/Windows (platform.platform() emits 'macOS-...' on modern Darwin runners). bump_dev_version targets backend.py VERSION, pyproject untouched via [tool.pdm.version] source=call.
 - [Phase 05.4]: gates.yml holds ONLY gate jobs (no publish/OIDC surface, T-05.4-04); publish stays in release.yml. full-os-matrix defaults true so PR CI (D-14) and release both exercise the new Windows core-test and macOS/Windows native-smoke gates. PR caller omits secrets: inherit (gates need none).
+- [Phase 06 Plan 01]: Docker Hub creds via org OAT at REPOSITORY scope (env-scope rejected: docker job declares no environment); stable/3.0.x ancestry recorded via user-run -s ours merge 8978b395 on main (D-10, real merge commit, zero drift)
 
 ### Roadmap Evolution
 
@@ -205,6 +207,6 @@ Recent decisions affecting current work:
 
 ## Session Continuity
 
-Last session: 2026-07-13T00:28:55.578Z
+Last session: 2026-07-13T14:49:54.551Z
 Stopped at: Phase 6 context gathered
 Resume file: .planning/phases/06-release-cut-3-0-16/06-CONTEXT.md

--- a/.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
+++ b/.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
@@ -297,7 +297,7 @@ strictly needs.
 - [x] Repo secret `DOCKERHUB_USERNAME` set (Settings → Secrets and variables → Actions) — verified 2026-07-13 via `gh api .../actions/secrets` (repository scope)
 - [x] Repo secret `DOCKERHUB_TOKEN` set (access token, not the account password) — verified 2026-07-13 via `gh api .../actions/secrets` (repository scope)
 - [x] Read the Docs GitHub integration connected; tag rules allow the Actions bot to force-update tags `3` and `3.0` (see section 5 — no per-patch activation rule) — user-confirmed in RTD UI 2026-07-13; tag ruleset 18840408 is deletion-only (force-update: verify-on-run)
-- [ ] One-time `-s ours` ancestry merge landed on `main` (section 6b — `stable/3.0.x` is diverged today and `branch-sync` WILL fail without it)
+- [x] One-time `-s ours` ancestry merge landed on `main` (section 6b) — verified 2026-07-13: merge `8978b395` on `origin/main`, two parents (`c4dc2df2` main + `0679bf51` stable tip), `merge-base --is-ancestor` prints FF-OK, `git diff` across the merge empty (zero content drift)
 - [x] No ruleset/protection blocks the Actions bot pushing `stable/3.0.x` (none exists as of 2026-07-12 — re-check if rules were added; section 6a) — re-verified 2026-07-13: classic protection 404, only disabled "Default" branch ruleset
 - [ ] Pre-tag check passes: `git merge-base --is-ancestor origin/stable/3.0.x <release-commit>` (A4; section 6c)
 - [x] Repo setting **"Allow GitHub Actions to create and approve pull requests"** enabled (Settings → Actions → General — required by the `dev-bump` job) — verified 2026-07-13, `can_approve_pull_request_reviews: true`

--- a/.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
+++ b/.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
@@ -289,18 +289,18 @@ Complete every box before pushing the first real `MAJOR.MINOR.PATCH` tag. Boxes
 marked **(dry-run)** are the only ones the CI-04 `workflow_dispatch` dry-run
 strictly needs.
 
-- [ ] **(dry-run)** GitHub Environment `testpypi` exists (Settings → Environments)
-- [ ] **(dry-run)** TestPyPI trusted publisher exists — repo `datafolklabs/cement`, workflow `release.yml`, env `testpypi` (or blank)
-- [ ] GitHub Environment `release` exists **with required reviewers** (Settings → Environments)
-- [ ] PyPI trusted publisher exists — repo `datafolklabs/cement`, workflow `release.yml`, env `release`
-- [ ] Docker Hub access token minted with push rights to `datafolklabs/cement` (OAT / bot-account PAT / maintainer PAT — see section 4)
-- [ ] Repo secret `DOCKERHUB_USERNAME` set (Settings → Secrets and variables → Actions)
-- [ ] Repo secret `DOCKERHUB_TOKEN` set (access token, not the account password)
-- [ ] Read the Docs GitHub integration connected; tag rules allow the Actions bot to force-update tags `3` and `3.0` (see section 5 — no per-patch activation rule)
+- [x] **(dry-run)** GitHub Environment `testpypi` exists (Settings → Environments) — verified 2026-07-13 via `gh api .../environments`
+- [x] **(dry-run)** TestPyPI trusted publisher exists — repo `datafolklabs/cement`, workflow `release.yml`, env `testpypi` (or blank) — proven by green dry-run 29212487225
+- [x] GitHub Environment `release` exists **with required reviewers** (Settings → Environments) — verified 2026-07-13, reviewer `derks`
+- [x] PyPI trusted publisher exists — repo `datafolklabs/cement`, workflow `release.yml`, env `release` — user-confirmed in PyPI UI 2026-07-13 (D-09 session)
+- [x] Docker Hub access token minted with push rights to `datafolklabs/cement` (OAT / bot-account PAT / maintainer PAT — see section 4) — org OAT path (D-11 preferred), user-confirmed 2026-07-13
+- [x] Repo secret `DOCKERHUB_USERNAME` set (Settings → Secrets and variables → Actions) — verified 2026-07-13 via `gh api .../actions/secrets` (repository scope)
+- [x] Repo secret `DOCKERHUB_TOKEN` set (access token, not the account password) — verified 2026-07-13 via `gh api .../actions/secrets` (repository scope)
+- [x] Read the Docs GitHub integration connected; tag rules allow the Actions bot to force-update tags `3` and `3.0` (see section 5 — no per-patch activation rule) — user-confirmed in RTD UI 2026-07-13; tag ruleset 18840408 is deletion-only (force-update: verify-on-run)
 - [ ] One-time `-s ours` ancestry merge landed on `main` (section 6b — `stable/3.0.x` is diverged today and `branch-sync` WILL fail without it)
-- [ ] No ruleset/protection blocks the Actions bot pushing `stable/3.0.x` (none exists as of 2026-07-12 — re-check if rules were added; section 6a)
+- [x] No ruleset/protection blocks the Actions bot pushing `stable/3.0.x` (none exists as of 2026-07-12 — re-check if rules were added; section 6a) — re-verified 2026-07-13: classic protection 404, only disabled "Default" branch ruleset
 - [ ] Pre-tag check passes: `git merge-base --is-ancestor origin/stable/3.0.x <release-commit>` (A4; section 6c)
-- [ ] Repo setting **"Allow GitHub Actions to create and approve pull requests"** enabled (Settings → Actions → General — required by the `dev-bump` job)
+- [x] Repo setting **"Allow GitHub Actions to create and approve pull requests"** enabled (Settings → Actions → General — required by the `dev-bump` job) — verified 2026-07-13, `can_approve_pull_request_reviews: true`
 - [ ] `testpypi` environment deployment branches restricted to `main` + tags (section 1 hardening — after feature-branch dry-run testing is done)
 - [ ] `CHANGELOG.md` has a finalized `## <version>` section (NOT `- DEVELOPMENT`) — preflight (D-02) hard-fails otherwise (dry-runs tolerate the DEVELOPMENT marker; only real tag pushes require finalization)
 - [ ] Package version (`cement.core.backend.VERSION`) equals the tag being pushed — preflight hard-fails otherwise

--- a/.planning/phases/06-release-cut-3-0-16/06-01-PLAN.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-01-PLAN.md
@@ -1,0 +1,245 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
+autonomous: false
+requirements: [REL-03, REL-04]
+user_setup:
+  - service: docker-hub
+    why: "Multi-arch image push (docker job) — no OIDC, needs a scoped access token (D-11)"
+    env_vars:
+      - name: DOCKERHUB_USERNAME
+        source: "Repo Settings -> Secrets and variables -> Actions (org name for OAT, or bot username)"
+      - name: DOCKERHUB_TOKEN
+        source: "Docker Hub -> OAT (org, repo-scoped) preferred, else bot PAT, else maintainer PAT (never the password)"
+    dashboard_config:
+      - task: "Mint Docker Hub access token with Image Push on datafolklabs/cement"
+        location: "Docker Hub -> datafolklabs org -> Identity & auth -> Access tokens (OAT), or account PAT"
+      - task: "Confirm PyPI trusted publisher exists (repo datafolklabs/cement, workflow release.yml, env release)"
+        location: "PyPI -> Manage -> cement -> Publishing (Trusted Publishers)"
+      - task: "Confirm Read the Docs GitHub integration connected; no per-patch activation rule"
+        location: "Read the Docs -> cement project -> Admin -> Integrations"
+      - task: "Confirm GitHub Environment release has required reviewers"
+        location: "GitHub -> datafolklabs/cement -> Settings -> Environments -> release"
+
+must_haves:
+  truths:
+    - "Repo secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN are both set (docker job can log in)"
+    - "PyPI trusted publisher confirmed present (repo datafolklabs/cement, workflow release.yml, env release) — enables REL-04 publish"
+    - "RTD GitHub integration confirmed connected with no per-patch activation rule"
+    - "GitHub Environment release has at least one required reviewer (the single approval gate)"
+    - "stable/3.0.x is an ancestor of main (branch-sync fast-forward precondition for REL-03) via a real -s ours merge commit"
+  artifacts:
+    - ".planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md pre-first-tag checklist boxes checked off with live evidence"
+  key_links:
+    - "release / testpypi environment OIDC claims match the trusted publishers (invalid-publisher otherwise)"
+    - "the -s ours merge on main records the ancestry link the branch-sync job depends on"
+---
+
+<objective>
+Close every open pre-first-tag provisioning blocker so the live 3.0.16 release
+run can complete end-to-end. This is the guided checkpoint session locked as the
+FIRST plan of the phase (D-09): the agent presents exact provider values, the
+user clicks through provider UIs (Docker Hub, PyPI, RTD, GitHub Settings), and
+the agent verifies each item via `gh api`/`git` where verifiable and checks it
+off in the runbook. Provisioning has zero code dependencies, so surprises
+surface earliest.
+
+Two hard blockers are open (Docker Hub secrets not set; stable/3.0.x not an
+ancestor of main) and two provider-UI items are unverifiable from the repo
+(PyPI trusted publisher, RTD integration) — all confirmed live at planning time.
+
+Purpose: The release pipeline is inert until external provider state exists; a
+missing PyPI publisher fails the real publish at the approval gate, and a
+missing ancestry link fails branch-sync. Closing these before the tag push is
+the whole point of doing provisioning first.
+Output: A fully checked pre-first-tag checklist in 05.4-PROVISIONING.md and a
+real `-s ours` merge commit recording stable/3.0.x ancestry on main.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+@.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+@.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
+</context>
+
+<artifacts_produced>
+## Artifacts this phase produces (Plan 01 scope)
+- Repo secrets `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (GitHub, created by user)
+- A merge commit on `main` recording `stable/3.0.x` ancestry (message
+  `chore: record stable/3.0.x ancestry for release fast-forward`) — created by
+  the USER directly on main (D-10), NOT a repo file this plan edits
+- Checked-off boxes in `.planning/.../05.4-PROVISIONING.md` "Pre-first-tag checklist"
+No new code symbols, classes, functions, or CLI flags are created this phase.
+</artifacts_produced>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Re-verify live provisioning state from the repo</name>
+  <read_first>
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Provisioning State Inventory (LIVE)" table — items #1-#12)
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md ("Pre-first-tag checklist")
+  </read_first>
+  <action>
+    Refresh every gh/git-verifiable checklist item because provisioning state is
+    live and may have changed since research. Run these checks and capture output
+    verbatim for the SUMMARY: `gh api repos/datafolklabs/cement/environments`
+    (confirm `release` + `testpypi` exist; confirm `release` has a required
+    reviewer), `gh api repos/datafolklabs/cement/actions/secrets` (list secret
+    names — DOCKERHUB_USERNAME / DOCKERHUB_TOKEN presence), `gh api
+    repos/datafolklabs/cement/actions/permissions/workflow` (confirm
+    can_approve_pull_request_reviews), `gh api
+    repos/datafolklabs/cement/rulesets/18840408` (confirm the "Force Tags"
+    ruleset rules are still deletion-only), and `git fetch origin main
+    stable/3.0.x` then `git merge-base --is-ancestor origin/stable/3.0.x
+    origin/main`. Classify each of the 12 inventory items as GREEN / OPEN /
+    UNVERIFIABLE-FROM-HERE. Do NOT change any state in this task — it is a
+    read-only refresh that feeds the guided session in Task 2/3.
+  </action>
+  <verify>
+    <automated>gh api repos/datafolklabs/cement/environments --jq '.environments[].name' | grep -q release</automated>
+  </verify>
+  <acceptance_criteria>
+    - Output records secret presence: DOCKERHUB_USERNAME and DOCKERHUB_TOKEN each shown as SET or ABSENT
+    - `git merge-base --is-ancestor origin/stable/3.0.x origin/main` exit code recorded (non-zero == ancestry OPEN)
+    - Environment `release` reviewer presence recorded from `gh api .../environments/release`
+    - A 12-row state table (GREEN/OPEN/UNVERIFIABLE) is produced for the SUMMARY, matching or updating RESEARCH item numbers #1-#12
+  </acceptance_criteria>
+  <done>Live provisioning state is re-inventoried; the two hard blockers (Docker secrets, ancestry) and two provider-UI items (PyPI publisher, RTD) are explicitly identified with current status.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Guided provider-UI provisioning session (D-09, D-11)</name>
+  <read_first>
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md (sections 1, 2, 4, 5 + "Exact match values" table)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Pitfall 5" Docker OAT/PAT path; Assumptions A1/A2)
+  </read_first>
+  <action>
+    Drive the guided provisioning session: for each open item, present the exact
+    provider value, wait for the user to complete the provider-UI step, then
+    verify from the repo. Verify Docker secrets landed via `gh api
+    repos/datafolklabs/cement/actions/secrets` (both DOCKERHUB_USERNAME and
+    DOCKERHUB_TOKEN present). Confirm the release-environment reviewer via `gh api
+    repos/datafolklabs/cement/environments/release`. PyPI trusted-publisher and RTD
+    integration are provider-UI-only (unverifiable from the repo) — record the
+    user's confirmation. Check off each corresponding box in 05.4-PROVISIONING.md's
+    pre-first-tag checklist as evidence lands.
+  </action>
+  <what-built>
+    Task 1 produced the current-state inventory. The agent now presents, item by
+    item, the EXACT provider values to enter and the verification it will run
+    after each. Blocking item to close: Docker Hub secrets DOCKERHUB_USERNAME +
+    DOCKERHUB_TOKEN (D-11 token preference order: org OAT scoped to
+    datafolklabs/cement with Image Push -> username `datafolklabs`; else bot-account
+    PAT; else maintainer PAT — never the account password). Provider-UI items to
+    CONFIRM (create only if absent): PyPI trusted publisher (repo
+    `datafolklabs/cement`, workflow filename `release.yml`, environment `release`);
+    RTD GitHub integration connected with NO per-patch activation rule; GitHub
+    Environment `release` has a required reviewer.
+  </what-built>
+  <how-to-verify>
+    1. Docker Hub: mint the token per the D-11 preference order, then add both
+       repo secrets at GitHub -> Settings -> Secrets and variables -> Actions.
+       Agent verifies via `gh api repos/datafolklabs/cement/actions/secrets` that
+       both names now appear.
+    2. PyPI: open PyPI -> Manage -> cement -> Publishing and confirm a GitHub
+       Actions trusted publisher exists with EXACTLY repo datafolklabs/cement,
+       workflow release.yml, environment release. If absent, add it (or add a
+       pending publisher). Report back present/created.
+    3. RTD: open Read the Docs -> cement -> Admin -> Integrations and confirm the
+       GitHub integration is connected; confirm there is NO automation rule that
+       activates three-part (per-patch) tags. Report back.
+    4. GitHub Environment: confirm `release` lists a required reviewer.
+    Agent checks off each corresponding box in 05.4-PROVISIONING.md's
+    "Pre-first-tag checklist" as evidence lands.
+  </how-to-verify>
+  <resume-signal>Type "provisioned" once Docker secrets are set and PyPI/RTD/release-env are confirmed, or describe which item is blocked (e.g. Docker plan lacks OAT support — fall back per runbook section 4).</resume-signal>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: One-time stable/3.0.x ancestry merge on main (D-10)</name>
+  <read_first>
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md (section 6b "One-time reconcile REQUIRED")
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Pitfall 1" squash/rebase destroys the second parent)
+  </read_first>
+  <action>
+    Prepare and hand the USER the exact `-s ours` merge command sequence (with the
+    resolved refs filled in), have the user run it directly on main, then verify.
+    Confirm the ancestry link now holds via `git fetch origin main && git
+    merge-base --is-ancestor origin/stable/3.0.x origin/main && echo FF-OK`, confirm
+    the new tip is a real merge commit with two parents (`git log --merges -1
+    --format='%P' origin/main`), and confirm zero content drift (`git diff
+    <merge>^ <merge>` empty). Do NOT run the merge yourself and do NOT accept a
+    squashed/rebased PR — the second parent must survive (Pitfall 1).
+  </action>
+  <what-built>
+    The agent hands the USER the exact command sequence to record stable/3.0.x
+    ancestry as a REAL merge commit directly on main: fetch origin main +
+    stable/3.0.x, switch to main and ff-only pull, then `git merge -s ours
+    origin/stable/3.0.x -m "chore: record stable/3.0.x ancestry for release
+    fast-forward"`, confirm zero content change with `git diff HEAD^ HEAD` (must
+    print nothing), `git push origin main`. This MUST be a real merge commit run
+    on main (not a squashed/rebased PR — that destroys the second parent and
+    branch-sync still fails; Pitfall 1). This is the sole sanctioned direct-to-main
+    action this phase (D-10), and it changes no file content.
+  </what-built>
+  <how-to-verify>
+    After the user runs the sequence and pushes, the agent verifies:
+    `git fetch origin main && git merge-base --is-ancestor origin/stable/3.0.x
+    origin/main && echo FF-OK` (must print FF-OK), and confirms the merge commit
+    has two parents via `git log --merges -1 --format='%P' origin/main` (two
+    SHAs), and that `git diff <merge>^ <merge>` is empty (zero content drift).
+  </how-to-verify>
+  <resume-signal>Type "ancestry-recorded" after the merge is pushed to main; agent confirms FF-OK before the phase advances.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| maintainer -> Docker Hub | Minting an access token that CI will use to push images |
+| CI -> PyPI (OIDC) | Trusted-publisher exchange with env `release` claim |
+| CI -> Docker Hub | Token-based login for the multi-arch push |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06-01 | Information Disclosure | DOCKERHUB_TOKEN secret | high | mitigate | Prefer org OAT repo-scoped to datafolklabs/cement (D-11); never store the account password; fall back bot-PAT before maintainer-PAT — narrowest blast radius available |
+| T-06-02 | Spoofing | PyPI trusted publisher | high | mitigate | Confirm exact-match (repo/release.yml/env release); do NOT add a long-lived PyPI token secret (OIDC only) |
+| T-06-03 | Elevation of Privilege | release environment approval | medium | accept | 05.4 control unchanged — single required reviewer gate; Task 1/2 confirm reviewer present |
+| T-06-SC | Tampering | pip/package installs | low | accept | Phase installs no new packages (RESEARCH "Package Legitimacy Audit — Not applicable"); no legitimacy gate to run |
+</threat_model>
+
+<verification>
+- `gh api repos/datafolklabs/cement/actions/secrets` lists both DOCKERHUB_USERNAME and DOCKERHUB_TOKEN
+- `git merge-base --is-ancestor origin/stable/3.0.x origin/main` exits 0 (FF-OK)
+- The `## Pre-first-tag checklist` in 05.4-PROVISIONING.md has all blocking boxes checked (Docker secrets, ancestry merge, release env reviewers) and PyPI/RTD confirmed
+</verification>
+
+<success_criteria>
+Both hard blockers closed (Docker secrets set; stable/3.0.x is an ancestor of
+main via a real merge commit) and both provider-UI items confirmed (PyPI trusted
+publisher present, RTD integration connected). The pre-first-tag checklist is
+fully accounted for with live evidence.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-release-cut-3-0-16/06-01-SUMMARY.md` when done
+</output>

--- a/.planning/phases/06-release-cut-3-0-16/06-01-SUMMARY.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-01-SUMMARY.md
@@ -1,0 +1,141 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 01
+subsystem: infra
+tags: [release, provisioning, github-actions, docker-hub, pypi, oidc, rtd, git-ancestry]
+
+# Dependency graph
+requires:
+  - phase: 05.4-github-actions-release-workflow
+    provides: release.yml/gates.yml pipeline, 05.4-PROVISIONING.md runbook with exact match values
+provides:
+  - Docker Hub repo secrets DOCKERHUB_USERNAME + DOCKERHUB_TOKEN (org OAT path, D-11)
+  - PyPI trusted publisher confirmed (repo datafolklabs/cement, workflow release.yml, env release)
+  - RTD GitHub integration confirmed connected, no per-patch activation rule
+  - stable/3.0.x ancestry recorded on main via real -s ours merge 8978b395 (branch-sync FF precondition)
+  - Pre-first-tag checklist in 05.4-PROVISIONING.md checked off with live evidence
+affects: [06-02 release-prep, 06-03 dry-run, 06-04 tag-and-live-run, 06-05 post-release]
+
+# Tech tracking
+tech-stack:
+  added: []
+  patterns: [guided D-09 provider-UI checkpoint session with per-item gh-api evidence verification]
+
+key-files:
+  created:
+    - .planning/phases/06-release-cut-3-0-16/06-01-provisioning-inventory.md
+  modified:
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md
+
+key-decisions:
+  - "Docker Hub credentials minted via org OAT (D-11 preferred path); DOCKERHUB_USERNAME=datafolklabs"
+  - "Secrets must live at REPOSITORY scope — release-environment scope rejected because the docker job declares no environment and would see empty credentials"
+  - "Ancestry recorded via user-run -s ours merge directly on main (D-10), not a PR — second parent preserved (Pitfall 1)"
+
+patterns-established:
+  - "Evidence-gated checkbox discipline: no runbook box checked without gh api / git output or explicit user confirmation for provider-UI-only items"
+
+requirements-completed: [REL-03, REL-04]
+
+coverage:
+  - id: D1
+    description: "Docker Hub secrets DOCKERHUB_USERNAME + DOCKERHUB_TOKEN set as repository secrets"
+    requirement: REL-04
+    verification:
+      - kind: other
+        ref: "gh api repos/datafolklabs/cement/actions/secrets — both names listed, total 2"
+        status: pass
+    human_judgment: false
+  - id: D2
+    description: "stable/3.0.x is an ancestor of main via a real -s ours merge commit (branch-sync FF precondition)"
+    requirement: REL-03
+    verification:
+      - kind: other
+        ref: "git merge-base --is-ancestor origin/stable/3.0.x origin/main → FF-OK; merge 8978b395 parents c4dc2df2 + 0679bf51; diff across merge empty"
+        status: pass
+    human_judgment: false
+  - id: D3
+    description: "PyPI trusted publisher (datafolklabs/cement / release.yml / env release) and RTD GitHub integration (no per-patch rule) confirmed"
+    requirement: REL-04
+    verification: []
+    human_judgment: true
+    rationale: "Provider-UI state on PyPI and Read the Docs is unreadable from the repo; user confirmed both in the D-09 guided session"
+
+# Metrics
+duration: ~35min (across 3 checkpoint continuations)
+completed: 2026-07-13
+status: complete
+---
+
+# Phase 06 Plan 01: Pre-First-Tag Provisioning Summary
+
+**Both hard release blockers closed — Docker Hub repo secrets set via org OAT and stable/3.0.x ancestry recorded on main via merge 8978b395 — with PyPI trusted publisher and RTD integration user-confirmed, leaving only Plan-02 items (CHANGELOG/VERSION) open on the pre-first-tag checklist.**
+
+## Performance
+
+- **Duration:** ~35 min wall-clock across the guided session (3 checkpoint round-trips)
+- **Completed:** 2026-07-13
+- **Tasks:** 3/3 (1 auto + 2 blocking human-verify checkpoints)
+- **Files modified:** 2
+
+## Accomplishments
+
+- Re-inventoried all 12 provisioning items live (`gh api`/`git`) — state matched the 2026-07-12 research; produced the 12-row GREEN/OPEN/UNVERIFIABLE table in `06-01-provisioning-inventory.md`
+- Closed blocker #7: `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` now exist as repository secrets (org OAT path per D-11), verified via `gh api repos/datafolklabs/cement/actions/secrets`
+- Closed blocker #8: user ran the one-time `-s ours` ancestry merge directly on main (D-10); verified FF-OK, two parents (`c4dc2df2` + `0679bf51`), zero content drift at merge `8978b395`
+- Recorded user confirmations for the two provider-UI-only items: PyPI trusted publisher (exact match values) and RTD GitHub integration (no per-patch activation rule)
+- Checked off 11 of 15 pre-first-tag checklist boxes in `05.4-PROVISIONING.md` with dated live evidence
+
+## Task Commits
+
+Each task was committed atomically on `gsd/phase-6-release-cut-3-0-16`:
+
+1. **Task 1: Re-verify live provisioning state** - `e2421f2f` (docs)
+2. **Task 2: Guided provider-UI provisioning session** - `d6be41e7` (docs)
+3. **Task 3: stable/3.0.x ancestry merge verification** - `dee1fa5a` (docs)
+
+Additionally on `main` (user-run, sanctioned by D-10): `8978b395` `chore: record stable/3.0.x ancestry for release fast-forward`.
+
+## Files Created/Modified
+
+- `.planning/phases/06-release-cut-3-0-16/06-01-provisioning-inventory.md` - Task 1 verbatim check output + 12-row state table
+- `.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md` - Pre-first-tag checklist boxes checked with live evidence annotations
+
+## Decisions Made
+
+- **Repository-scope secrets, not environment-scope:** the user's first placement put both Docker secrets on the `release` environment; verification caught that the `docker` job declares no `environment:` and would resolve empty credentials. User re-added at repository scope; env copies may remain as harmless shadows.
+- **Org OAT chosen** for Docker Hub (D-11 preferred path) — `DOCKERHUB_USERNAME=datafolklabs`.
+
+## Deviations from Plan
+
+### Checkpoint-caught issues (not auto-fixes — human-verify gate worked as designed)
+
+**1. Docker secrets initially placed at the wrong scope**
+- **Found during:** Task 2 verification (first "provisioned" signal)
+- **Issue:** Secrets landed as `release`-environment secrets; the `docker` job (release.yml L212) declares no environment, so it would see empty credentials at runtime
+- **Fix:** Reported back with exact fix steps; user re-added both as repository secrets; re-verified via `gh api` (total: 2)
+- **Committed in:** `d6be41e7` (evidence recorded in commit body)
+
+**2. Working copy left on `main` after the user's ancestry merge**
+- **Found during:** Task 3 verification
+- **Issue:** The user ran the merge sequence in this working copy and remained on `main`, making the runbook appear unchecked (main predates the phase-branch commits)
+- **Fix:** Verified local `main` == pushed `origin/main` and clean, switched back to `gsd/phase-6-release-cut-3-0-16`; no work lost
+- **Committed in:** n/a (no repo change needed)
+
+## Known Stubs
+
+None.
+
+## Remaining open checklist items (expected, out of this plan's scope)
+
+- Pre-tag ancestry check against the actual release commit (Plan 04, at tag handoff)
+- `testpypi` environment deployment-branch restriction (optional hardening)
+- CHANGELOG finalization + `backend.py` VERSION bump (Plan 02 release-prep PR)
+- Tag ruleset force-update behavior: verify-on-run during the live release (Pitfall 4)
+
+## Self-Check: PASSED
+
+- `06-01-provisioning-inventory.md` exists: FOUND
+- `05.4-PROVISIONING.md` ancestry + secrets boxes checked: FOUND
+- Commits `e2421f2f`, `d6be41e7`, `dee1fa5a` on phase branch: FOUND
+- Merge `8978b395` on `origin/main` with two parents: FOUND

--- a/.planning/phases/06-release-cut-3-0-16/06-01-provisioning-inventory.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-01-provisioning-inventory.md
@@ -1,0 +1,75 @@
+# 06-01 Task 1 — Live Provisioning Re-Inventory
+
+**Refreshed:** 2026-07-13 (start of the D-09 guided session)
+**Method:** read-only `gh api` / `git` checks against `datafolklabs/cement`.
+No provisioning state was changed by this task (feeds Task 2/3).
+
+## Verbatim check output
+
+```
+# gh api repos/datafolklabs/cement/environments --jq '.environments[].name'
+copilot
+release
+testpypi
+
+# gh api .../environments/release  (protection_rules)
+{"name":"release","rules":[{"reviewers":["derks"],"type":"required_reviewers"}]}
+
+# gh api .../actions/secrets --jq '.secrets[].name'
+(empty — no repo secrets set)
+
+# gh api .../actions/permissions/workflow
+{"default_workflow_permissions":"write","can_approve_pull_request_reviews":true}
+
+# gh api .../rulesets/18840408
+name="Github Actions Release Force Tags" enforcement=active target=tag
+conditions.ref_name.include=["refs/tags/3","refs/tags/3.0"]
+rules=["deletion"]  bypass=[]
+
+# gh api .../rulesets  (all)
+{id:797205,  name:"Default",                         enforcement:disabled, target:branch}
+{id:18840408,name:"Github Actions Release Force Tags",enforcement:active,   target:tag}
+
+# gh api .../branches/stable%2F3.0.x/protection
+404 "Branch not protected"
+
+# git fetch origin main stable/3.0.x
+# git merge-base --is-ancestor origin/stable/3.0.x origin/main ; echo $?
+1            # non-zero == NOT an ancestor == ancestry OPEN
+# git rev-parse origin/stable/3.0.x -> 0679bf51e4c24d900528979884e66c5e14f28ef1
+# git rev-parse origin/main         -> c4dc2df23ffc6a5e120a714b2343e372bba0716f
+
+# CHANGELOG.md header
+## 3.0.15 - DEVELOPMENT (will be released as stable/3.0.16)
+
+# cement/core/backend.py
+VERSION = (3, 0, 15, 'final', 0)  # pragma: nocover  # version constant
+```
+
+## 12-row state table (maps RESEARCH inventory #1–#12)
+
+| # | Checklist item | Status | Evidence |
+|---|----------------|--------|----------|
+| 1 | GitHub Env `release` + required reviewers | GREEN | reviewer `derks` present |
+| 2 | GitHub Env `testpypi` | GREEN | env exists |
+| 3 | TestPyPI trusted publisher | UNVERIFIABLE-FROM-HERE | provider-UI; proven green by dry-run 29212487225 |
+| 4 | Allow Actions create/approve PRs | GREEN | `can_approve_pull_request_reviews: true` |
+| 5 | `stable/3.0.x` unprotected / bot can push | GREEN | 404 not protected; no `stable/*` ruleset (only disabled "Default") |
+| 6 | Tag ruleset allows bot force-update `3`/`3.0` | GREEN (verify-on-run) | active, rules=`["deletion"]` only, no bypass — deletion ≠ force-update |
+| 7 | Docker secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN` | **OPEN (blocker)** | secrets list empty — both ABSENT |
+| 8 | `stable/3.0.x` is an ancestor of `main` | **OPEN (blocker)** | `merge-base --is-ancestor` exit 1 |
+| 9 | PyPI trusted publisher (repo/`release.yml`/env `release`) | UNVERIFIABLE-FROM-HERE | provider-UI; confirm in D-09 |
+| 10 | RTD GitHub integration; no per-patch activation rule | UNVERIFIABLE-FROM-HERE | provider-UI; confirm in D-09 |
+| 11 | CHANGELOG finalized (`## 3.0.16 - <date>`) | OPEN (closed by Plan 02) | still `## 3.0.15 - DEVELOPMENT` |
+| 12 | `backend.py` VERSION == tag | OPEN (closed by Plan 02) | currently `(3, 0, 15, 'final', 0)` |
+
+## Net
+
+State unchanged since 2026-07-12 research. Two hard blockers OPEN for this plan:
+- **#7 Docker Hub secrets** — close in the Task 2 guided session (D-11 token order).
+- **#8 `stable/3.0.x` ancestry** — close in Task 3 via the USER's `-s ours` merge (D-10).
+
+Two provider-UI items (#9 PyPI publisher, #10 RTD) remain UNVERIFIABLE from the
+repo and must be user-confirmed in the Task 2 session. Item #6 stays "verify on
+first live run." A new `copilot` GitHub environment has appeared since research —
+harmless (unused by `release.yml`), noted only for completeness.

--- a/.planning/phases/06-release-cut-3-0-16/06-02-PLAN.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-02-PLAN.md
@@ -1,0 +1,231 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 02
+type: execute
+wave: 2
+depends_on: ["06-01"]
+files_modified:
+  - CHANGELOG.md
+  - cement/core/backend.py
+autonomous: false
+requirements: [REL-01, DOCS-03]
+must_haves:
+  truths:
+    - "CHANGELOG.md top section header reads exactly `## 3.0.16 - <Month D, YYYY>` (begins `## 3.0.16`, contains no `DEVELOPMENT` marker) — preflight and gh-release awk-extraction depend on it"
+    - "A 2-4 sentence highlights paragraph sits between the 3.0.16 header and the first `Bugs:` bucket"
+    - "Every user-visible change in `git log 3.0.14..HEAD` (after planning-artifact filtering) is enumerated in the 3.0.16 section (DOCS-03 / success criterion 1)"
+    - "All five buckets (Bugs, Features, Refactoring, Misc, Deprecations) are preserved in order; every entry condensed to 1-3 release-notes-altitude lines with its `[area]` prefix intact; no entry deleted or merged (including `[dev]`)"
+    - "`from cement.utils.version import get_version` returns '3.0.16' after the backend.py edit"
+    - "The change lands on main via one reviewed release-prep PR — no direct commits to main"
+  artifacts:
+    - "CHANGELOG.md with a finalized `## 3.0.16 - <date>` section (highlights + 5 buckets)"
+    - "cement/core/backend.py VERSION tuple == (3, 0, 16, 'final', 0) with the trailing pragma comment preserved"
+    - "A release-prep PR (branch gsd/phase-6-release-cut-*) merged to main"
+  key_links:
+    - "pyproject.toml reads the version dynamically via [tool.pdm.version] source=call getter=cement.utils.version:get_version — editing backend.py alone satisfies REL-01"
+    - "release.yml gh-release job awk-extracts the `## 3.0.16` section into the GitHub Release body"
+---
+
+<objective>
+Author the single release-prep PR (D-05): finalize the CHANGELOG.md
+`## 3.0.15 - DEVELOPMENT` section to a released `## 3.0.16 - <date>` section
+(D-01 completeness cross-check, D-02 header rename, D-03 highlights paragraph,
+D-04 condensation) and bump the single version-of-record `VERSION` tuple in
+`cement/core/backend.py` to `(3, 0, 16, 'final', 0)` (REL-01). The user reviews
+and merges the PR; the merged main commit is what later gets tagged.
+
+Purpose: The workflow's preflight guard hard-fails on an unfinalized changelog
+or a version/tag mismatch, and the gh-release job ships whatever the 3.0.16
+section says — so this PR is the human gate on release-notes completeness
+(DOCS-03 success criterion 1). It is a reconcile of an already-populated section,
+not a rewrite.
+Output: One merged release-prep PR carrying the finalized changelog + version bump.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+@.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+@.planning/phases/06-release-cut-3-0-16/06-PATTERNS.md
+@CHANGELOG.md
+@cement/core/backend.py
+@CLAUDE.md
+</context>
+
+<artifacts_produced>
+## Artifacts this phase produces (Plan 02 scope)
+- Finalized `## 3.0.16 - <date>` section in `CHANGELOG.md` (new highlights
+  paragraph — first narrative intro in the changelog, no prior analog)
+- `VERSION = (3, 0, 16, 'final', 0)` in `cement/core/backend.py` (value change
+  only; no new symbol — VERSION already exists)
+- Release-prep PR branch `gsd/phase-6-release-cut-*`
+No new code symbols, classes, functions, or CLI flags are created.
+</artifacts_produced>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: D-01 git-log cross-check + finalize the 3.0.16 changelog section</name>
+  <read_first>
+    - CHANGELOG.md (the current `## 3.0.15 - DEVELOPMENT (will be released as stable/3.0.16)` section AND the finalized `## 3.0.14 - May 5, 2025` section for header/altitude convention)
+    - .planning/phases/06-release-cut-3-0-16/06-PATTERNS.md (`CHANGELOG.md` pattern assignment: header form, bucket order, highlights placement, condensation altitude)
+    - CLAUDE.md ("Changelog Maintenance" — bucket taxonomy, planning-artifact filtering, revert-pair filtering)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Pitfall 6" enumeration completeness; D-01..D-04 in User Constraints)
+  </read_first>
+  <action>
+    Reconcile then finalize. (D-01) Run `git log --oneline 3.0.14..HEAD` and
+    classify each commit: drop planning-artifact commits (`docs(NN.N):`,
+    `docs(state):`, `docs(quick-...):`), drop revert-pairs and same-branch
+    overwrites; bucket the rest by Conventional Commit type (`fix:`->Bugs,
+    `feat:`->Features, `refactor:`->Refactoring, `chore:` deps/tooling->Misc,
+    deprecation surfaces->Deprecations). Diff that derived set against the
+    already-populated buckets and flag any user-visible change that is MISSING or
+    any entry that no longer matches what shipped — add/correct entries so the
+    section is complete. (D-02) Rename the header from `## 3.0.15 - DEVELOPMENT
+    (will be released as stable/3.0.16)` to `## 3.0.16 - <Month D, YYYY>` using
+    today's date in the `## 3.0.14 - May 5, 2025` format; the header MUST begin
+    `## 3.0.16` and MUST NOT contain `DEVELOPMENT`. (D-03) Insert a 2-4 sentence
+    highlights paragraph between the header and the first `Bugs:` bucket covering
+    the four locked themes: Python 3.10-3.14 matrix, warn-only deprecations with
+    3.2.0 removals signposted, automated GitHub Actions release workflow, and
+    fully-typed modernized `cement generate` templates. (D-04) Condense every
+    entry to 1-3 release-notes-altitude lines (what changed + why it matters to
+    users), dropping dev-forensic detail; keep ALL five buckets in order (Bugs,
+    Features, Refactoring, Misc, Deprecations), preserve every `[area]` prefix,
+    and do NOT delete or merge any entry — including `[dev]` entries. Preserve
+    empty buckets with `- None` per prior-section convention.
+  </action>
+  <verify>
+    <automated>grep -q '^## 3\.0\.16 - ' CHANGELOG.md && ! sed -n '/^## 3\.0\.16/,/^## 3\.0\.1[0-5]/p' CHANGELOG.md | grep -q 'DEVELOPMENT' && echo OK</automated>
+  </verify>
+  <acceptance_criteria>
+    - `grep '^## 3.0.16 - ' CHANGELOG.md` matches exactly one finalized header (date in `Month D, YYYY` form)
+    - The 3.0.16 section contains no literal DEVELOPMENT marker
+    - A highlights paragraph (2-4 sentences) appears before the first `Bugs:` line and names all four locked themes
+    - All five bucket labels (Bugs:, Features:, Refactoring:, Misc:, Deprecations:) are present and ordered
+    - The SUMMARY records the D-01 cross-check result: list of commits added/corrected, or an explicit "no gaps found — section already complete"
+    - No pre-existing entry was deleted or merged (entry count per bucket >= prior section, minus none)
+  </acceptance_criteria>
+  <done>The changelog's top section is a complete, condensed, correctly-headed `## 3.0.16 - <date>` release-notes section with a highlights intro.</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Bump the version of record to 3.0.16 (REL-01)</name>
+  <read_first>
+    - cement/core/backend.py (the entire 3-line file — the VERSION tuple at line 3)
+    - .planning/phases/06-release-cut-3-0-16/06-PATTERNS.md (`cement/core/backend.py` pattern: change the third tuple element only; preserve the trailing pragma comment byte-for-byte)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Pitfall 2" do NOT run bump_dev_version.py for this bump; REL-01 single-source-of-truth)
+  </read_first>
+  <action>
+    Edit ONLY the third element of the VERSION tuple in cement/core/backend.py
+    from `(3, 0, 15, 'final', 0)` to `(3, 0, 16, 'final', 0)`, preserving the
+    trailing `  # pragma: nocover  # version constant` comment exactly (the
+    dev-bump script's regex and mypy both depend on this line shape). Do NOT edit
+    pyproject.toml or cement/__init__.py — both derive the version dynamically
+    (pyproject via `[tool.pdm.version] source="call"
+    getter="cement.utils.version:get_version"`; __init__ re-exports
+    get_version()). Do NOT run scripts/bump_dev_version.py — it also prepends a
+    fresh DEVELOPMENT changelog section, which would break the finalized header
+    from Task 1 (Pitfall 2). After editing, prove there is no other 3.0.15
+    version-of-record with `grep -rn "3\.0\.15\|(3, 0, 15" --include="*.py"
+    --include="*.toml" . | grep -v ".planning/"` (expect only
+    scripts/bump_dev_version.py's regex-doc comment, which is not a version of
+    record).
+  </action>
+  <verify>
+    <automated>python -c "from cement.utils.version import get_version; assert get_version()=='3.0.16', get_version(); print('REL-01 OK', get_version())"</automated>
+  </verify>
+  <acceptance_criteria>
+    - `get_version()` returns exactly `3.0.16`
+    - `cement/core/backend.py` line reads `VERSION = (3, 0, 16, 'final', 0)  # pragma: nocover  # version constant` (trailing comment intact)
+    - `grep -rn "3\.0\.15\|(3, 0, 15" --include="*.py" --include="*.toml" . | grep -v ".planning/"` returns only the bump_dev_version.py regex-doc comment line (no version-of-record hit)
+    - pyproject.toml and cement/__init__.py are unchanged
+  </acceptance_criteria>
+  <done>The single version of record reads 3.0.16 and no stale 3.0.15 version-of-record remains anywhere in source.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 3: Open the release-prep PR, prove gates green, hand off for review + merge (D-05)</name>
+  <read_first>
+    - CLAUDE.md ("Branching Policy" — no direct commits to main; "Commit Conventions" — Conventional Commits + 78-char wrap)
+    - .planning/phases/06-release-cut-3-0-16/06-PATTERNS.md ("Quality gates hold green (release-prep PR)" — make comply / make test / make audit-public-api)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Sampling Rate" — full PR CI must be green before merge)
+  </read_first>
+  <action>
+    Commit Task 1 + Task 2 on the phase branch as a Conventional Commit
+    (`chore(release): finalize changelog and bump version to 3.0.16`, 78-char
+    wrap), run the local gate suite (`make comply`, `make test`,
+    `make audit-public-api`) so the PR arrives green, push, and open a PR to main
+    with `gh pr create` (body summarizes changelog finalization + version bump and
+    links this plan). Then hand off to the user for review + merge and verify main
+    carries 3.0.16 afterward. No direct commits to main.
+  </action>
+  <what-built>
+    The agent commits Task 1 + Task 2 on the current phase branch
+    (gsd/phase-6-release-cut-*) as a Conventional Commit
+    (e.g. `chore(release): finalize changelog and bump version to 3.0.16`,
+    78-char wrap), pushes, and opens a PR to main via `gh pr create`. Before
+    handing off, the agent runs the local gate suite so the PR arrives green:
+    `make comply` (ruff + mypy), `make test` (100% coverage — needs Redis:6379 +
+    memcached:11211 up), and `make audit-public-api` (byte-for-byte). The PR body
+    summarizes the changelog finalization + version bump and links this plan.
+  </what-built>
+  <how-to-verify>
+    1. The user reviews the PR diff — especially the changelog completeness
+       (DOCS-03 success criterion 1 is a human judgment) and the highlights
+       paragraph wording.
+    2. The user confirms PR CI (gates.yml via build_and_test.yml) is green across
+       the Python matrix.
+    3. The user merges the PR to main (a normal merge is fine here — unlike the
+       D-10 ancestry merge, this PR carries file content and its merge method
+       does not affect branch-sync).
+    Agent then confirms main contains the finalized changelog + version:
+    `git fetch origin main && git show origin/main:cement/core/backend.py | grep VERSION`
+    shows 3.0.16, and `git show origin/main:CHANGELOG.md | grep '^## 3.0.16 - '` matches.
+  </how-to-verify>
+  <resume-signal>Type "merged" once the release-prep PR is merged to main, or describe requested changelog edits for another pass.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| release-prep PR -> main | Human-reviewed change gate; the merged commit becomes the tagged release |
+| CHANGELOG.md -> CI (data) | Preflight + gh-release consume the section text verbatim |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06-04 | Tampering | version-of-record (backend.py) | medium | mitigate | Single-source edit; grep proves no second 3.0.15 source; get_version assertion gates the value |
+| T-06-05 | Repudiation | incomplete release notes | medium | mitigate | D-01 git-log cross-check + PR review is the human gate on DOCS-03 completeness (preflight only checks finalization, not enumeration) |
+| T-06-SC | Tampering | pip/package installs | low | accept | No package/dependency changes in this PR (CHANGELOG + backend.py only); RESEARCH legitimacy audit N/A |
+</threat_model>
+
+<verification>
+- `grep '^## 3.0.16 - ' CHANGELOG.md` matches; no `DEVELOPMENT` in the section
+- `get_version()` == 3.0.16; no stale 3.0.15 version-of-record in source
+- `make comply`, `make test` (100% coverage), `make audit-public-api` all exit 0 on the PR branch
+- The finalized changelog + version bump are present on origin/main after merge
+</verification>
+
+<success_criteria>
+One reviewed release-prep PR is merged to main carrying a complete, condensed
+`## 3.0.16 - <date>` changelog section (highlights + 5 ordered buckets, every
+entry preserved) and the single VERSION tuple bumped to (3, 0, 16, 'final', 0),
+with full PR CI green.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-release-cut-3-0-16/06-02-SUMMARY.md` when done
+</output>

--- a/.planning/phases/06-release-cut-3-0-16/06-03-PLAN.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-03-PLAN.md
@@ -1,0 +1,166 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 03
+type: execute
+wave: 3
+depends_on: ["06-02"]
+files_modified: []
+autonomous: false
+requirements: [CI-04, REL-02]
+must_haves:
+  truths:
+    - "A `workflow_dispatch` run of release.yml against main (the merged, finalized 3.0.16 commit) completes with conclusion success (CI-04)"
+    - "The preflight job passes its finalized-changelog guard and version==intended-version guard against the real 3.0.16 inputs"
+    - "The testpypi-smoke matrix job is green on all five legs (Python 3.10, 3.11, 3.12, 3.13, 3.14) — install + import App + App().run() + version assert (REL-02)"
+    - "The dry-run does NOT reach publish-pypi (event-gated to push only) — no real PyPI publish occurs"
+  artifacts:
+    - "A recorded GREEN workflow_dispatch run id for release.yml against the finalized commit (the CI-04 evidence baseline for the live run)"
+  key_links:
+    - "preflight reads CHANGELOG.md `## 3.0.16` header + backend.py VERSION from the merged commit"
+    - "testpypi-publish uploads 3.0.16 to TestPyPI (first upload of this version); the later real tag run skip-exists and re-smokes the identical bytes"
+---
+
+<objective>
+Run one final `workflow_dispatch` dry-run of `release.yml` against main AFTER the
+release-prep PR is merged (D-06) — the first validation of preflight against the
+real finalized changelog + 3.0.16 version, and the first upload of 3.0.16 to
+TestPyPI. This closes CI-04 (workflow validated end-to-end against TestPyPI
+before the cut) against the exact bytes the live tag run will re-smoke.
+
+Purpose: TestPyPI filenames are immutable — running the dry-run only against the
+merged, finalized commit guarantees the 3.0.16 artifact on TestPyPI matches what
+gets published to PyPI (Pitfall 3). The dry-run is event-gated out of
+publish-pypi, so it validates the whole pre-publish half with zero real-publish
+risk.
+Output: A green workflow_dispatch run id, recorded as the CI-04 baseline.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+@.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+@.github/workflows/release.yml
+</context>
+
+<artifacts_produced>
+## Artifacts this phase produces (Plan 03 scope)
+- A GREEN `workflow_dispatch` run of `release.yml` against main (run id recorded
+  in the SUMMARY) — the CI-04 evidence
+- A fresh `cement 3.0.16` upload on TestPyPI (first upload of this version;
+  produced by the workflow's testpypi-publish job, not by this plan directly)
+No repo files are modified and no new code symbols are created.
+</artifacts_produced>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Trigger the final dry-run against the finalized main commit (D-06)</name>
+  <read_first>
+    - .github/workflows/release.yml (preflight job guards; testpypi-publish `environment: testpypi` + skip-existing; the `if: github.event_name == 'push'` gate on publish-pypi)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Code Examples -> Final dry-run"; "Pitfall 3" TestPyPI immutability; CI-04 row)
+  </read_first>
+  <action>
+    Confirm origin/main carries the finalized changelog + 3.0.16 version first
+    (`git fetch origin main`; `git show origin/main:cement/core/backend.py | grep
+    VERSION` shows 3.0.16; `git show origin/main:CHANGELOG.md` top header is
+    `## 3.0.16 - <date>` with no DEVELOPMENT). Then dispatch the dry-run:
+    `gh workflow run release.yml -R datafolklabs/cement --ref main`. Capture the
+    dispatched run id via `gh run list -R datafolklabs/cement --workflow
+    release.yml --limit 1 --json databaseId,headSha,event,status`. Do NOT trigger
+    this before the release-prep PR is merged — a WIP-branch dry-run would freeze
+    wrong bytes on TestPyPI's immutable index (Pitfall 3).
+  </action>
+  <verify>
+    <automated>gh run list -R datafolklabs/cement --workflow release.yml --limit 1 --json event,headSha --jq '.[0].event' | grep -q workflow_dispatch</automated>
+  </verify>
+  <acceptance_criteria>
+    - origin/main confirmed at 3.0.16 (backend.py VERSION + finalized changelog header) BEFORE dispatch
+    - A workflow_dispatch run of release.yml is dispatched against main; run id + headSha recorded
+    - The dispatched run's headSha equals the merged release-prep commit on main
+  </acceptance_criteria>
+  <done>The final pre-tag dry-run is running against the finalized 3.0.16 commit on main.</done>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Monitor the dry-run to completion and confirm CI-04 + REL-02 green</name>
+  <read_first>
+    - .github/workflows/release.yml (job graph: preflight -> gates -> build -> testpypi-publish -> testpypi-smoke matrix)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Open Questions #4" monitoring cadence; REL-02 validation row; run 29212487225 green baseline)
+  </read_first>
+  <action>
+    Poll the dispatched run with `gh run view <run-id> -R datafolklabs/cement
+    --json status,conclusion,jobs` at each job transition and report a one-line
+    status to the user. On completion, confirm overall conclusion success,
+    preflight guards passed, all five testpypi-smoke legs (3.10-3.14) green, and
+    publish-pypi SKIPPED (event-gated to push). Record the run id as the CI-04
+    baseline. If any job fails against finalized main, treat it as a real
+    regression/provisioning gap — surface it and do NOT tag (a changelog/version
+    fix routes back to Plan 02).
+  </action>
+  <what-built>
+    The agent monitors the run with `gh run view <run-id> -R datafolklabs/cement
+    --json status,conclusion,jobs` at each job transition and reports a one-line
+    status to the user per the D-16-discretion cadence. On completion it confirms:
+    overall `conclusion: success`; preflight passed (finalized-changelog + version
+    guards); the testpypi-smoke matrix is green on all five Python legs
+    (3.10-3.14); and publish-pypi was SKIPPED (event-gated to push). It records
+    the run id as the CI-04 baseline and notes the 3.0.16 TestPyPI upload is now
+    frozen (the live run will skip-exist + re-smoke it).
+  </what-built>
+  <how-to-verify>
+    1. `gh run view <run-id> -R datafolklabs/cement --json status,conclusion` shows
+       conclusion success.
+    2. `gh run view <run-id> -R datafolklabs/cement --json jobs` shows every
+       testpypi-smoke matrix leg (3.10, 3.11, 3.12, 3.13, 3.14) with conclusion
+       success and publish-pypi with conclusion skipped.
+    3. If any gate fails: the run is against finalized main, so a failure is a
+       real regression or a provisioning gap — surface it, do NOT tag. A changelog
+       or version fix means another release-prep PR pass (back to Plan 02).
+    User confirms the run is green end-to-end.
+  </how-to-verify>
+  <resume-signal>Type "dry-run-green" once the workflow_dispatch run is conclusion=success with all 5 smoke legs green, or describe the failing job for triage.</resume-signal>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| CI -> TestPyPI (OIDC) | testpypi-publish uploads via the `testpypi` env claim |
+| dispatch input -> release.yml | workflow_dispatch event drives the dry-run path |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06-06 | Tampering | TestPyPI immutable artifact | medium | mitigate | Dry-run only against merged, finalized main so the frozen 3.0.16 bytes match the eventual PyPI publish (Pitfall 3) |
+| T-06-07 | Elevation of Privilege | publish-pypi during dry-run | high | accept | 05.4 control: publish-pypi is event-gated `if: github.event_name == 'push'` — a workflow_dispatch dry-run cannot reach it |
+| T-06-SC | Tampering | pip/package installs | low | accept | No packages installed by this plan (RESEARCH legitimacy audit N/A) |
+</threat_model>
+
+<verification>
+- `gh run view <run-id> --json conclusion` == success
+- All 5 testpypi-smoke legs (3.10-3.14) green; publish-pypi skipped
+- Run headSha == merged release-prep commit on main
+- CI-04 run id recorded in the SUMMARY as the pre-tag baseline
+</verification>
+
+<success_criteria>
+One final workflow_dispatch dry-run of release.yml against the finalized 3.0.16
+commit on main completes conclusion=success with the 5-Python TestPyPI smoke
+green and publish-pypi correctly skipped — CI-04 satisfied and 3.0.16 uploaded
+to TestPyPI for the live run to re-smoke.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-release-cut-3-0-16/06-03-SUMMARY.md` when done
+</output>

--- a/.planning/phases/06-release-cut-3-0-16/06-04-PLAN.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-04-PLAN.md
@@ -1,0 +1,218 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 04
+type: execute
+wave: 4
+depends_on: ["06-01", "06-03"]
+files_modified: []
+autonomous: false
+requirements: [REL-02, REL-03]
+must_haves:
+  truths:
+    - "The pre-tag fast-forward precondition holds: `git merge-base --is-ancestor origin/stable/3.0.x <release-sha>` prints FF-OK before the tag is pushed"
+    - "The USER pushes the `3.0.16` tag on the exact merged release-prep SHA (D-07); the agent never pushes the tag"
+    - "The live release.yml run (push event) passes gates and testpypi-smoke (REL-02) and reaches the single `release`-environment approval gate"
+    - "After the user approves, publish-pypi succeeds and the publish-side jobs run: docker, branch-sync (stable/3.0.x fast-forward), tag-sync (3 / 3.0), gh-release, dev-bump"
+    - "The `3.0.16` git tag exists and the GitHub Release page is published with the awk-extracted `## 3.0.16` changelog body (REL-03)"
+  artifacts:
+    - "The `3.0.16` git tag on the release commit"
+    - "A published GitHub Release for 3.0.16 with the changelog section as its body"
+  key_links:
+    - "tag push (3.*) triggers release.yml; the release environment approval is the single manual publish stop; gh-release awk-extracts the `## 3.0.16` section"
+    - "branch-sync fast-forwards stable/3.0.x (depends on the Plan 01 ancestry merge); tag-sync force-updates 3/3.0 and fires the RTD rebuild"
+---
+
+<objective>
+Make the human tag push zero-risk and shepherd the live release run through its
+single approval gate. The agent proves the pre-tag preconditions (correct SHA,
+green ancestry check) and hands the USER the exact verified command sequence
+(D-07); the USER pushes the `3.0.16` tag personally — the human act of tagging is
+the release trigger. The agent then monitors the run, pauses for the user's
+GitHub-UI approval at the `release` environment gate, and verifies the tag +
+GitHub Release land (REL-03), applying the D-08 failure policy if a job fails.
+
+Purpose: Tag push triggers the real publish path; a wrong SHA or a missed
+ancestry precondition would either tag the wrong commit or fail branch-sync
+mid-release. The agent's job is to make the push safe, not to perform it.
+Output: A published 3.0.16 tag + GitHub Release, with PyPI/Docker/branch/tag
+sync jobs complete.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+@.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+@.github/workflows/release.yml
+</context>
+
+<artifacts_produced>
+## Artifacts this phase produces (Plan 04 scope)
+- The `3.0.16` git tag (pushed by the USER, D-07)
+- A published GitHub Release page for `3.0.16` (created by the workflow's
+  gh-release job; body = awk-extracted `## 3.0.16` changelog section)
+- Fast-forwarded `stable/3.0.x`; force-updated moving tags `3` and `3.0`
+  (workflow branch-sync / tag-sync jobs)
+No repo files are modified by this plan and no new code symbols are created.
+</artifacts_produced>
+
+<tasks>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 1: Pre-tag safety checks + hand the USER the exact tag commands (D-07)</name>
+  <read_first>
+    - .github/workflows/release.yml (trigger `on: push: tags` pattern; gh-release awk extraction)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Code Examples -> Pre-tag safety + tag handoff"; D-07; Provisioning items #6/#8 tag ruleset + ancestry)
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md (section 6c pre-tag verification)
+  </read_first>
+  <action>
+    Resolve the exact release SHA (`git fetch origin main && git rev-parse
+    origin/main`), prove the FF precondition (`git merge-base --is-ancestor
+    origin/stable/3.0.x <sha> && echo FF-OK`), and confirm no `3.0.16` tag exists
+    yet (`git ls-remote --tags origin 3.0.16` empty). Present the USER the exact
+    two-line push sequence (`git tag 3.0.16 <sha>` then `git push origin 3.0.16`)
+    with the SHA filled in. Do NOT push the tag yourself (D-07). After the user
+    pushes, confirm the tag landed and the tag-triggered release run started.
+  </action>
+  <what-built>
+    The agent resolves the exact SHA to tag — the merged release-prep commit on
+    main: `git fetch origin main && git rev-parse origin/main` — and proves the
+    fast-forward precondition BEFORE tagging: `git merge-base --is-ancestor
+    origin/stable/3.0.x <sha> && echo FF-OK` (must print FF-OK; depends on the
+    Plan 01 D-10 ancestry merge). It confirms no unprefixed `3.0.16` tag already
+    exists (`git ls-remote --tags origin 3.0.16` is empty). It then presents the
+    USER the exact two-line push sequence (`git tag 3.0.16 <sha>` then `git push
+    origin 3.0.16`) with the resolved SHA filled in. The agent does NOT push the
+    tag (D-07: the human act of tagging is the source of truth).
+  </what-built>
+  <how-to-verify>
+    1. Agent shows: resolved SHA, FF-OK ancestry result, and empty tag-exists check.
+    2. The USER runs the two commands to create and push the `3.0.16` tag on that SHA.
+    3. Agent confirms the tag landed: `git ls-remote --tags origin 3.0.16` returns
+       the expected SHA, and a new release.yml run keyed on the tag has started
+       (`gh run list -R datafolklabs/cement --workflow release.yml --limit 1
+       --json event,headBranch` shows event push on ref 3.0.16).
+  </how-to-verify>
+  <resume-signal>Type "tagged" once `git push origin 3.0.16` succeeds and the release run has started; agent confirms the tag SHA matches the finalized main commit.</resume-signal>
+</task>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 2: Shepherd the live run and pause for the release-environment approval (D-07, D-08)</name>
+  <read_first>
+    - .github/workflows/release.yml (publish-pypi `environment: release`; all publish-side jobs `needs: publish-pypi`)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Live-run monitoring + approval"; "Open Questions #4" cadence; Pitfall 7 dev-bump PR shows no CI)
+  </read_first>
+  <action>
+    Poll the tag-triggered run with `gh run view <run-id> -R datafolklabs/cement
+    --json status,conclusion,jobs`, reporting a one-line status at each job
+    transition. Confirm gates + all five testpypi-smoke legs (REL-02) pass, then
+    STOP at the `release` environment approval gate and prompt the user to approve
+    in the GitHub UI. After approval, resume monitoring the publish-side fan-out
+    (docker, branch-sync, tag-sync, gh-release, dev-bump). Apply the D-08 failure
+    policy: pre-publish failure -> delete tag, fix, re-tag; post-publish partial
+    failure -> `gh run rerun <run-id> --failed` (tag stays).
+  </action>
+  <what-built>
+    The agent monitors the tag-triggered run with `gh run view <run-id> -R
+    datafolklabs/cement --json status,conclusion,jobs`, reporting a one-line
+    status at each job transition. It confirms gates + testpypi-smoke (REL-02, the
+    real-run smoke of the frozen 3.0.16 artifact) pass, then STOPS at the `release`
+    environment approval gate — the single manual publish stop. The user approves
+    in the GitHub UI (Actions -> run -> "Review deployments" -> approve `release`).
+    The agent resumes monitoring the publish-side fan-out (docker, branch-sync,
+    tag-sync, gh-release, dev-bump, post-release-checklist).
+  </what-built>
+  <how-to-verify>
+    1. Before approval: `gh run view <run-id> --json jobs` shows gates + all 5
+       testpypi-smoke legs green and publish-pypi waiting on the environment.
+    2. The user approves the `release` deployment in the GitHub UI.
+    3. Apply D-08 failure policy: a gate/preflight failure BEFORE publish -> delete
+       the tag (`git push --delete origin 3.0.16 && git tag -d 3.0.16`), fix on a
+       branch, re-tag. A publish-side partial failure AFTER publish-pypi succeeds
+       (docker / branch-sync / tag-sync / gh-release / dev-bump) -> `gh run rerun
+       <run-id> -R datafolklabs/cement --failed` (the tag STAYS); manual completion
+       only if a re-run cannot recover.
+  </how-to-verify>
+  <resume-signal>Type "approved-and-publishing" after approving the release deployment; agent resumes monitoring the publish-side jobs.</resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 3: Verify the tag, GitHub Release, and branch/tag sync landed (REL-03)</name>
+  <read_first>
+    - .github/workflows/release.yml (gh-release job -> RELEASE_BODY.md; branch-sync / tag-sync jobs)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md (REL-03 validation row; Pitfall 4 "Force Tags" ruleset verify-on-run)
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md (section 5 RTD moving-tag; section 6 branch fast-forward)
+  </read_first>
+  <action>
+    After the run completes, confirm the release artifacts: the tag exists (`git
+    ls-remote --tags origin 3.0.16`); the GitHub Release is published with the
+    changelog body (`gh release view 3.0.16 -R datafolklabs/cement --json
+    tagName,body,isDraft` — isDraft false, body begins with the 3.0.16 highlights
+    paragraph); branch-sync fast-forwarded stable/3.0.x (`git fetch origin
+    stable/3.0.x && git merge-base --is-ancestor origin/stable/3.0.x <release-sha>`
+    and confirm stable/3.0.x tip == release SHA); tag-sync force-updated the moving
+    tags (`git ls-remote --tags origin 3 3.0` both point at the release SHA). If
+    tag-sync failed with a protected-ref error, this is the Pitfall 4
+    verify-on-run case: add the GitHub Actions app to the "Force Tags" ruleset
+    bypass list and `gh run rerun <run-id> --failed` (D-08). Confirm the docker job
+    pushed multi-arch tags and that a dev-bump PR was opened (its zero-CI state is
+    the accepted Pitfall 7 tradeoff — do not block on missing checks).
+  </action>
+  <verify>
+    <automated>gh release view 3.0.16 -R datafolklabs/cement --json tagName,isDraft --jq '.tagName' | grep -qx 3.0.16</automated>
+  </verify>
+  <acceptance_criteria>
+    - `gh release view 3.0.16` shows tagName 3.0.16, isDraft false, and a body starting with the 3.0.16 highlights paragraph
+    - `git ls-remote --tags origin 3.0.16` returns the release SHA
+    - stable/3.0.x tip == release SHA (branch-sync succeeded)
+    - moving tags `3` and `3.0` both point at the release SHA (tag-sync succeeded; RTD rebuild triggered)
+    - a dev-bump PR (bump to 3.0.17) exists (verified via `gh pr list`), handed to Plan 05
+  </acceptance_criteria>
+  <done>The 3.0.16 tag and GitHub Release are published, branch-sync/tag-sync completed, and the dev-bump PR is open for Plan 05 to merge.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| human -> git (tag push) | The tag push is the release trigger (D-07) |
+| CI -> PyPI (OIDC, real) | publish-pypi authenticates via id-token + release env claim |
+| approval gate -> publish-side | All publish jobs `needs: publish-pypi`; single manual stop |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06-08 | Elevation of Privilege | unapproved publish | high | mitigate | Single `release` environment reviewer gate; agent pauses at the gate, user approves in UI (05.4 control confirmed in Plan 01) |
+| T-06-09 | Tampering | wrong-SHA / duplicate tag | high | mitigate | Pre-tag SHA resolution + FF-OK ancestry + empty tag-exists check before the human push; D-08 delete-and-re-tag recovery for pre-publish failures |
+| T-06-10 | Spoofing | PyPI publish auth | high | accept | OIDC trusted publisher only — no long-lived token added (do NOT create a PYPI_TOKEN secret); 05.4 control |
+| T-06-11 | Tampering | template injection via github.ref_name | low | accept | 05.4 control — ref_name passed via env:, regex-escaped in awk/grep, never inline-spliced |
+| T-06-SC | Tampering | pip/package installs | low | accept | No packages installed by this plan (RESEARCH legitimacy audit N/A) |
+</threat_model>
+
+<verification>
+- FF-OK ancestry printed before the tag push; tag pushed by the USER on the correct SHA
+- Live run: gates + 5 testpypi-smoke legs green; user-approved release-env gate; publish-pypi success
+- `gh release view 3.0.16` published (isDraft false) with the changelog body
+- stable/3.0.x fast-forwarded; moving tags 3/3.0 updated; dev-bump PR opened
+</verification>
+
+<success_criteria>
+The USER pushes the 3.0.16 tag on the verified SHA; the live release run passes
+gates + smoke, the user approves the single release-environment gate, PyPI
+publish succeeds, and the tag + GitHub Release (with changelog body) are
+published with branch-sync/tag-sync complete and the dev-bump PR opened.
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-release-cut-3-0-16/06-04-SUMMARY.md` when done
+</output>

--- a/.planning/phases/06-release-cut-3-0-16/06-05-PLAN.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-05-PLAN.md
@@ -1,0 +1,231 @@
+---
+phase: 06-release-cut-3-0-16
+plan: 05
+type: execute
+wave: 5
+depends_on: ["06-04"]
+files_modified:
+  - .planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md
+  - .planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md
+  - .planning/REQUIREMENTS.md
+  - .planning/ROADMAP.md
+autonomous: false
+requirements: [REL-04, REL-05]
+must_haves:
+  truths:
+    - "A clean-venv `pip install cement==3.0.16` from production PyPI + import App + App().run() round-trip + version assert succeeds (REL-04, D-13)"
+    - "The dev-bump PR is merged; `get_version()` on main returns 3.0.17 and a fresh `## 3.0.17 - DEVELOPMENT` section heads CHANGELOG.md (REL-05, D-12)"
+    - "A release-announcement draft artifact exists, derived from the finalized 3.0.16 changelog highlights (D-14) — one source of truth for what shipped"
+    - "REL-01..05, CI-04, and DOCS-03 are flipped to Complete in REQUIREMENTS.md traceability with live evidence (run ids / gh release / clean-venv proof)"
+    - "06-VERIFICATION.md records status passed with per-truth evidence for all 5 ROADMAP success criteria"
+  artifacts:
+    - ".planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md (status: passed; requirement-coverage table flipping REL-01..05/CI-04/DOCS-03)"
+    - ".planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md (paste-ready announcement copy)"
+  key_links:
+    - "REQUIREMENTS.md traceability rows flip Pending->Complete; ROADMAP Phase 6 marked complete"
+    - "the dev-bump PR merge advances main to the 3.0.17 dev cycle (phase-end boundary per D-12; milestone completion is a separate session per D-15)"
+---
+
+<objective>
+Close the phase: verify the published 3.0.16 artifact installs cleanly from
+production PyPI (REL-04, D-13), merge the workflow-opened dev-bump PR to advance
+main to 3.0.17 (REL-05, D-12), draft the release-announcement copy from the
+finalized changelog highlights (D-14), and flip REL-01..05 / CI-04 / DOCS-03 to
+Complete with a 06-VERIFICATION.md. Phase 6 ends here at the requirement flips +
+VERIFICATION.md; milestone completion is a separate follow-up session (D-15).
+
+Purpose: The in-run 5-Python TestPyPI smoke already proved the identical bytes;
+REL-04 is the single independent production-PyPI confirmation. Merging the
+dev-bump PR reopens the dev cycle so downstream work targets 3.0.17. The
+announcement draft gives the user paste-ready copy without inventing fresh prose.
+Output: A verified, documented, closed Phase 6 with main on the 3.0.17 dev cycle.
+</objective>
+
+<execution_context>
+@$HOME/.claude/gsd-core/workflows/execute-plan.md
+@$HOME/.claude/gsd-core/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/PROJECT.md
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/REQUIREMENTS.md
+@.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+@.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+@.planning/phases/06-release-cut-3-0-16/06-PATTERNS.md
+@.planning/phases/05.4-github-actions-release-workflow/05.4-VERIFICATION.md
+@CHANGELOG.md
+</context>
+
+<artifacts_produced>
+## Artifacts this phase produces (Plan 05 scope)
+- `.planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md` (new)
+- `.planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md` (new — first
+  automated-release announcement; no prior analog, derived from the D-03
+  changelog highlights)
+- Flipped traceability rows in `.planning/REQUIREMENTS.md` and Phase 6 completion
+  in `.planning/ROADMAP.md`
+- (via the merged dev-bump PR, authored by the workflow, not this plan) main
+  advances to VERSION (3, 0, 17, ...) with a fresh `## 3.0.17 - DEVELOPMENT` section
+No new product code symbols, classes, functions, or CLI flags are created.
+</artifacts_produced>
+
+<tasks>
+
+<task type="checkpoint:human-verify" gate="blocking">
+  <name>Task 1: REL-04 clean-venv verification + merge the dev-bump PR (D-13, D-12, REL-05)</name>
+  <read_first>
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Code Examples -> REL-04 clean-venv verification"; D-12/D-13; Pitfall 7 dev-bump PR shows no CI)
+    - scripts/testpypi-smoke.py (the SmokeApp(argv=[]) App().run() round-trip pattern to mirror)
+  </read_first>
+  <action>
+    Run the REL-04 clean-venv check: create a throwaway venv, `pip install
+    cement==3.0.16` from production PyPI, import App, assert
+    get_version()=='3.0.16', run a minimal App().run() round-trip (mirroring
+    scripts/testpypi-smoke.py's SmokeApp(argv=[]) pattern), then deactivate. If the
+    install 404s, PyPI propagation may lag — retry briefly. Locate the
+    workflow-opened dev-bump PR (`gh pr list -R datafolklabs/cement --search "bump"
+    --json number,title,headRefName`), confirm its diff bumps VERSION to
+    (3, 0, 17, ...) and prepends `## 3.0.17 - DEVELOPMENT`, then hand off to the
+    user to merge it (its zero-CI state is the accepted Pitfall 7 tradeoff — do not
+    block). After merge, confirm origin/main advanced to 3.0.17.
+  </action>
+  <what-built>
+    The agent runs the REL-04 clean-venv check: create a throwaway venv, `pip
+    install cement==3.0.16` from production PyPI, then import App + assert
+    get_version()=='3.0.16' + a minimal App().run() round-trip (mirroring
+    scripts/testpypi-smoke.py's SmokeApp(argv=[]) pattern), then deactivate. It
+    then locates the workflow-opened dev-bump PR (`gh pr list -R
+    datafolklabs/cement --search "bump" --json number,title,headRefName`) and
+    confirms its diff bumps VERSION to (3, 0, 17, ...) and prepends a fresh
+    `## 3.0.17 - DEVELOPMENT` section. The dev-bump PR shows zero CI checks by
+    design (GITHUB_TOKEN anti-recursion, Pitfall 7 / accepted tradeoff #1) — this
+    is expected, not a blocker.
+  </what-built>
+  <how-to-verify>
+    1. Agent shows the clean-venv output: `pip install cement==3.0.16` succeeds and
+       the round-trip prints the 3.0.16 version (REL-04 OK). If the install fails
+       with "no matching distribution", PyPI propagation may lag — retry briefly.
+    2. The USER merges the dev-bump PR deliberately (do NOT wait for CI checks that
+       will never appear; main CI runs post-merge).
+    3. Agent confirms main advanced: `git fetch origin main && git show
+       origin/main:cement/core/backend.py | grep VERSION` shows 3.0.17, and
+       `git show origin/main:CHANGELOG.md` top header is `## 3.0.17 - DEVELOPMENT`.
+  </how-to-verify>
+  <resume-signal>Type "dev-bump-merged" once the 3.0.17 PR is merged and REL-04 clean-venv passed, or describe the install/round-trip failure.</resume-signal>
+</task>
+
+<task type="auto">
+  <name>Task 2: Draft the release announcement from the changelog highlights (D-14)</name>
+  <read_first>
+    - CHANGELOG.md (the finalized `## 3.0.16 - <date>` highlights paragraph + buckets — the single source of truth for "what shipped")
+    - .planning/phases/06-release-cut-3-0-16/06-PATTERNS.md ("06-ANNOUNCEMENT.md — NO ANALOG"; derive from highlights, do not invent prose)
+    - .planning/phases/06-release-cut-3-0-16/06-RESEARCH.md ("Don't Hand-Roll -> Announcement copy"; D-14)
+  </read_first>
+  <action>
+    Create .planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md as paste-ready
+    announcement copy DERIVED from the finalized 3.0.16 changelog highlights
+    paragraph (D-03) — do NOT write fresh prose or re-summarize the buckets from
+    scratch; the highlights are the one source of truth. Include: a short subject
+    line (e.g. "Cement 3.0.16 released"), the highlights paragraph (Python
+    3.10-3.14 matrix, warn-only deprecations with 3.2.0 removals signposted,
+    automated GitHub Actions release workflow, fully-typed modernized `cement
+    generate` templates), a `pip install -U cement` upgrade line, and links to the
+    GitHub Release + changelog. Note in the file that SENDING (mailing list /
+    Slack / GitBook) stays a human step on the emitted post-release checklist
+    issue (05.4 D-15, out of scope for this phase).
+  </action>
+  <verify>
+    <automated>test -f .planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md && grep -qi 'cement 3.0.16' .planning/phases/06-release-cut-3-0-16/06-ANNOUNCEMENT.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - 06-ANNOUNCEMENT.md exists with a subject line naming Cement 3.0.16
+    - Its body reuses the finalized changelog highlights (all four locked themes present), not freshly-invented prose
+    - It includes an upgrade line and a link to the GitHub Release / changelog
+    - It states that sending remains a human step (D-15 / post-release checklist)
+  </acceptance_criteria>
+  <done>A paste-ready announcement draft derived from the changelog highlights exists for the user to send when ready.</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Write 06-VERIFICATION.md and flip REL-01..05 / CI-04 / DOCS-03 (D-12)</name>
+  <read_first>
+    - .planning/phases/05.4-github-actions-release-workflow/05.4-VERIFICATION.md (frontmatter shape + body section headings to copy exactly)
+    - .planning/phases/06-release-cut-3-0-16/06-PATTERNS.md (`06-VERIFICATION.md` pattern: frontmatter fields, requirements-coverage row style)
+    - .planning/REQUIREMENTS.md (traceability table rows for REL-01..05, CI-04, DOCS-03)
+    - .planning/ROADMAP.md (Phase 6 entry + progress table)
+  </read_first>
+  <action>
+    Create .planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md mirroring
+    05.4-VERIFICATION.md's structure: YAML frontmatter (phase, verified ISO8601,
+    status: passed, score, behavior_unverified, overrides_applied, overrides[],
+    re_verification, gaps[], deferred[], human_verification[]) and body sections
+    (## Goal Achievement -> ### Observable Truths (ROADMAP Success Criteria) table,
+    ### Required Artifacts, ### Key Link Verification, ### Requirements Coverage,
+    ### Anti-Patterns Found, ### Human Verification Required, ### Gaps Summary).
+    Populate the Observable Truths table against the 5 ROADMAP success criteria
+    with live evidence: the CI-04 dry-run run id (Plan 03), the live release run id
+    + `gh release view 3.0.16` (Plan 04), the REL-04 clean-venv output (Plan 01/05
+    Task 1), and the 3.0.17 dev-bump merge (Task 1). In the Requirements Coverage
+    table, flip REL-01, REL-02, REL-03, REL-04, REL-05, CI-04, and DOCS-03 from
+    Pending to Complete/SATISFIED, each with a run-id / gh-release / clean-venv
+    citation. Then update .planning/REQUIREMENTS.md: change the traceability rows
+    for those seven IDs from `Pending` to `Complete` and check their `[ ]` boxes in
+    the requirement lists. Update .planning/ROADMAP.md: mark Phase 6 `[x]` in the
+    Phases list and set its row in the Progress table to Complete with today's
+    date. Record the phase-end boundary (D-12/D-15): the post-release checklist
+    issue (GitBook, notifications) stays open beyond the phase, and milestone
+    completion is a separate `/gsd-complete-milestone` session — list these under
+    ### Human Verification Required / deferred[], NOT as gaps.
+  </action>
+  <verify>
+    <automated>test -f .planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md && grep -q 'status: passed' .planning/phases/06-release-cut-3-0-16/06-VERIFICATION.md</automated>
+  </verify>
+  <acceptance_criteria>
+    - 06-VERIFICATION.md exists with status: passed and a score covering all 5 ROADMAP success criteria, each row citing live evidence (run id / gh release / clean-venv)
+    - The Requirements Coverage table flips REL-01, REL-02, REL-03, REL-04, REL-05, CI-04, DOCS-03 to Complete/SATISFIED
+    - `grep -E 'REL-0[1-5]|CI-04|DOCS-03' .planning/REQUIREMENTS.md` shows those rows as Complete (not Pending) in the traceability table
+    - ROADMAP.md shows Phase 6 `[x]` and its Progress-table row as Complete
+    - The post-release checklist + milestone completion are recorded as deferred/human-verification, NOT as gaps
+  </acceptance_criteria>
+  <done>Phase 6 is verified (status passed) with all 7 requirement IDs flipped to Complete and ROADMAP/REQUIREMENTS updated; the phase closes at the D-12 boundary.</done>
+</task>
+
+</tasks>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description |
+|----------|-------------|
+| production PyPI -> clean venv | Independent REL-04 install verification off the published artifact |
+| dev-bump PR -> main | Human-merged advance to the 3.0.17 dev cycle |
+
+## STRIDE Threat Register
+
+| Threat ID | Category | Component | Severity | Disposition | Mitigation Plan |
+|-----------|----------|-----------|----------|-------------|-----------------|
+| T-06-12 | Spoofing | published PyPI artifact | medium | mitigate | REL-04 clean-venv install + version assert + App().run() round-trip confirms the exact published bytes install and import (D-13) |
+| T-06-13 | Repudiation | requirement-flip without evidence | low | mitigate | Every flipped row in 06-VERIFICATION.md cites a run id / gh release / clean-venv proof (05.4 evidence-citation pattern) |
+| T-06-SC | Tampering | pip install (clean-venv check) | low | accept | Installs only the just-published `cement==3.0.16` from production PyPI for verification — the artifact this phase produced; no third-party package added |
+</threat_model>
+
+<verification>
+- REL-04: clean-venv `pip install cement==3.0.16` + App().run() round-trip prints 3.0.16
+- REL-05: dev-bump PR merged; origin/main get_version() == 3.0.17; fresh `## 3.0.17 - DEVELOPMENT`
+- 06-ANNOUNCEMENT.md exists (highlights-derived)
+- 06-VERIFICATION.md status passed; REL-01..05/CI-04/DOCS-03 flipped Complete in REQUIREMENTS.md; ROADMAP Phase 6 complete
+</verification>
+
+<success_criteria>
+The published 3.0.16 installs cleanly from production PyPI (REL-04), the dev-bump
+PR is merged advancing main to 3.0.17 (REL-05), a highlights-derived announcement
+draft exists (D-14), and 06-VERIFICATION.md (status passed) flips REL-01..05 /
+CI-04 / DOCS-03 to Complete with live evidence — Phase 6 closed at the D-12
+boundary, milestone completion deferred to a separate session (D-15).
+</success_criteria>
+
+<output>
+Create `.planning/phases/06-release-cut-3-0-16/06-05-SUMMARY.md` when done
+</output>

--- a/.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md
@@ -1,0 +1,241 @@
+# Phase 6: Release Cut 3.0.16 - Context
+
+**Gathered:** 2026-07-12
+**Status:** Ready for planning
+
+<domain>
+## Phase Boundary
+
+Run the 3.0.16 release using the machinery Phase 05.4 built and dry-run-validated
+(run 29212487225 GREEN end-to-end). The phase: complete the pre-first-tag
+provisioning checklist, audit and finalize the changelog, bump the version of
+record to 3.0.16, rehearse once more via `workflow_dispatch` dry-run, hand the
+user the tag-push commands, shepherd the live release run through the single
+approval gate, verify the published artifacts, merge the dev-bump PR (3.0.17),
+draft announcement copy, and flip the milestone requirement IDs
+(REL-01..05, CI-04, DOCS-03). Locked by ROADMAP success criteria (not re-decided
+here): changelog enumerates all user-visible changes; TestPyPI install proof on
+3.10–3.14; version-of-record reads 3.0.16 at tag time and 3.0.17 after; tag +
+GitHub Release + clean `pip install cement==3.0.16`; the workflow runs
+end-to-end with no manual intervention beyond the approved publish step.
+
+Locked by Phase 05.4 (carry forward, do not re-litigate): tag push is the
+canonical trigger with unprefixed tags (D-01/D-09); one approval stop via the
+`release` GitHub Environment (D-03/D-04); TestPyPI inline with `--skip-existing`
+idempotency (D-05/D-08); dry-run never publishes (D-06); dev-bump lands as an
+automated PR (D-12); notifications stay human steps on the emitted post-release
+checklist issue (D-15/D-16).
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Changelog finalization
+- **D-01:** Full git-log cross-check before finalization — diff
+  `git log 3.0.14..HEAD` against every entry in the `## 3.0.15 - DEVELOPMENT`
+  section; flag any user-visible change that's missing and any entry that no
+  longer matches what shipped. Success criterion 1 demands complete enumeration.
+- **D-02:** Section header renamed to `## 3.0.16 - <Month D, YYYY>` matching
+  the established convention (`## 3.0.14 - May 5, 2025`). The header MUST
+  begin `## 3.0.16` — the release workflow's `gh-release` job awk-extracts the
+  section by tag match, and preflight (05.4 D-02) validates it is finalized.
+- **D-03:** Add a short narrative highlights paragraph (2–4 sentences) at the
+  top of the 3.0.16 section — Python 3.10–3.14 matrix, new warn-only
+  deprecations, release automation, template modernization — above the
+  standard buckets. It becomes the top of the GitHub Release body.
+- **D-04:** Condense verbose entries at finalization: keep EVERY entry, edit
+  each to 1–3 lines at release-notes altitude (what changed + why it matters
+  to users); drop dev-time forensic detail — git history retains it. Do NOT
+  delete or merge `[dev]` entries.
+
+### Release-prep commit flow
+- **D-05:** One release-prep PR: a single branch (e.g. `gsd/phase-6-release-cut`)
+  carries changelog finalization + `cement/core/backend.py` VERSION bump to
+  `(3, 0, 16, 'final', 0)`. User reviews and merges; the resulting main commit
+  is what gets tagged. No direct commits to main.
+- **D-06:** One final `workflow_dispatch` dry-run against the merged release
+  commit on main before tagging — first validation of preflight against the
+  real finalized changelog + version. Accepted caveat (05.4 D-08): the dry-run
+  uploads 3.0.16 to TestPyPI; the real tag run skip-exists and smokes that
+  artifact — same commit, so no content drift.
+- **D-07:** The user pushes the tag personally (`git tag 3.0.16 && git push
+  origin 3.0.16`). The agent hands over the exact verified command sequence —
+  correct SHA, pre-tag ancestry check (`git merge-base --is-ancestor
+  origin/stable/3.0.x <sha>`) already proven green. Matches 05.4 D-01: the
+  human act of tagging is the source of truth.
+- **D-08:** Failure policy for the live run: gate failures = delete tag, fix,
+  re-tag (05.4 D-01, unchanged). Publish-side partial failure AFTER PyPI
+  publish succeeds (Docker buildx, branch-sync, gh-release, dev-bump): use
+  GitHub's re-run-failed-jobs on the same run — the tag stays; manual
+  completion only if a re-run cannot recover.
+
+### Provisioning completion
+- **D-09:** Guided checkpoint session as the FIRST plan of the phase — walk
+  `05.4-PROVISIONING.md`'s pre-first-tag checklist item-by-item: agent
+  presents exact values to enter, user clicks through provider UIs
+  (PyPI, Docker Hub, RTD, GitHub settings), agent verifies each item via
+  `gh api`/repo state where verifiable and checks it off in the runbook.
+  Provisioning has no code dependencies, so surprises surface earliest.
+- **D-10:** The one-time `stable/3.0.x` ancestry merge (`git merge -s ours`)
+  is run by the USER on main; the agent preps the exact command sequence and
+  verifies `merge-base --is-ancestor` afterward. Must be a real merge commit —
+  a rebase/squash-merged PR would destroy the merge parent and branch-sync
+  would fail.
+- **D-11:** Docker Hub credentials via an org access token (OAT) on the
+  `datafolklabs` org — repo-scoped, cleanest blast radius. Requires Docker
+  Team/Business; if the plan turns out not to support OAT at the checkpoint,
+  fall back per runbook section 4 (bot-account PAT preferred over maintainer
+  PAT).
+
+### Post-release wrap-up scope
+- **D-12:** Phase end = through dev-bump merge: PyPI + Docker + GitHub Release
+  live, dev-bump PR merged (VERSION `(3, 0, 17, ...)` + fresh
+  `## 3.0.17 - DEVELOPMENT` section), and REL-01..05 / CI-04 / DOCS-03 flipped
+  with a VERIFICATION.md. The emitted post-release checklist issue (GitBook
+  docs, notifications) stays open beyond the phase.
+- **D-13:** REL-04 verification is a single clean-venv check: `pip install
+  cement==3.0.16` from production PyPI + import + minimal `App().run()`
+  round-trip. The 5-Python matrix already proved the identical artifact from
+  TestPyPI inside the release run.
+- **D-14:** The phase drafts the release announcement copy (highlights-based,
+  from the finalized changelog) as a small artifact the user can paste into
+  the mailing list / Slack. Sending remains human (05.4 D-15 unchanged).
+- **D-15:** Milestone completion is a separate follow-up session — Phase 6
+  ends at requirement flips + VERIFICATION.md; the user invokes
+  `/gsd-complete-milestone` afterward.
+
+### Claude's Discretion
+- Exact plan/wave decomposition (provisioning-first is locked; the rest may
+  parallelize where file ownership allows).
+- Mechanics of the git-log cross-check (commit classification, filtering
+  planning-artifact commits per CLAUDE.md changelog rules).
+- Shape/wording of the condensed changelog entries and the highlights
+  paragraph (user reviews via the release-prep PR).
+- Announcement-copy format and where the draft artifact lives.
+- How dry-run/live-run monitoring is reported back during execution
+  (checkpoint cadence while the ~30–40 min runs are in flight).
+
+</decisions>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Release machinery & runbook (Phase 05.4 outputs — the contract this phase executes)
+- `.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md` —
+  the pre-first-tag checklist D-09's guided session walks, provider-exact
+  values, Docker Hub token paths (§4), RTD moving-tag model (§5),
+  `stable/3.0.x` ancestry merge procedure (§6), known accepted tradeoffs.
+- `.planning/phases/05.4-github-actions-release-workflow/05.4-CONTEXT.md` —
+  locked release-flow decisions D-01..D-16 carried into this phase.
+- `.github/workflows/release.yml` — the pipeline this phase runs: preflight →
+  gates → build → TestPyPI publish + smoke → approval → publish side
+  (PyPI, Docker, tag-sync, branch-sync, gh-release, dev-bump, checklist issue).
+- `.github/workflows/gates.yml` — reusable gate suite invoked by both PR CI
+  and the release run.
+- `scripts/testpypi-smoke.py`, `scripts/bump_dev_version.py` — smoke and
+  dev-bump mechanics referenced by the run.
+
+### Version & changelog (the files the release-prep PR touches)
+- `CHANGELOG.md` — `## 3.0.15 - DEVELOPMENT` section (~540 lines) to audit,
+  condense, and rename per D-01..D-04; header convention from
+  `## 3.0.14 - May 5, 2025`.
+- `cement/core/backend.py` — `VERSION = (3, 0, 15, 'final', 0)` is the single
+  version of record (pyproject reads it via `[tool.pdm.version]` source=call);
+  bump to `(3, 0, 16, 'final', 0)` in the release-prep PR.
+
+### Project-level constraints
+- `.planning/ROADMAP.md` — Phase 6 goal + 5 locked success criteria.
+- `.planning/REQUIREMENTS.md` — REL-01..REL-05, CI-04, DOCS-03 definitions and
+  the traceability table this phase flips.
+- `CLAUDE.md` — changelog maintenance rules (bucket taxonomy, planning-artifact
+  filtering) governing the D-01 cross-check, branching policy governing D-05.
+
+### External
+- https://github.com/datafolklabs/cement/issues/791 — the manual checklist the
+  automation replaces; the post-release checklist issue mirrors its style.
+- https://github.com/datafolklabs/cement/actions/runs/29212487225 — the GREEN
+  CI-04 dry-run baseline (what "working" looks like).
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- The entire release pipeline is built and validated — this phase RUNS it; no
+  workflow code changes are expected. If a workflow bug surfaces, fixes follow
+  the 05.4 precedent (small PR, re-dispatch dry-run).
+- `workflow_dispatch` dry-run mode (05.4 D-06) is the rehearsal vehicle for
+  D-06's final pre-tag validation.
+- `scripts/bump_dev_version.py` handles the post-release 3.0.17 bump inside
+  the workflow's dev-bump job — the phase only merges the resulting PR.
+- Provisioned already: `testpypi` GitHub Environment + TestPyPI trusted
+  publisher (the two dry-run items). Everything else on the pre-first-tag
+  checklist is open as of 2026-07-12.
+
+### Established Patterns
+- Conventional Commits + 78-char wrap; `docs(06):` prefix for planning
+  artifacts; no direct commits to main (D-05/D-10 both respect this).
+- `make audit-public-api` byte-for-byte green across every commit (Phase 3
+  D-04 lineage) — applies to the release-prep PR too.
+- 100% coverage + ruff + mypy gates hold; the release-prep PR triggers full
+  PR CI (gates.yml) before merge.
+- Checkpoint/human-verify pattern from 05.4-05 (provisioning confirmed via
+  checkpoint) — D-09's guided session reuses it.
+
+### Integration Points
+- Tag `3.0.16` on main → `release.yml` (trigger pattern matches unprefixed
+  `3.*` tags).
+- `release` GitHub Environment approval = the user, in the GitHub UI, at the
+  single publish gate.
+- Dev-bump PR is `GITHUB_TOKEN`-authored → shows zero CI checks
+  (anti-recursion; accepted tradeoff #1 in the runbook) — merging it is a
+  deliberate human step; main CI runs post-merge.
+- `stable/3.0.x` fast-forward and RTD moving tags `3`/`3.0` are handled by
+  the workflow's branch-sync/tag-sync jobs — but only AFTER the D-10 ancestry
+  merge lands.
+
+</code_context>
+
+<specifics>
+## Specific Ideas
+
+- Highlights paragraph themes (D-03): Python 3.10–3.14 matrix, warn-only
+  deprecations with 3.2.0 removals signposted, automated release workflow,
+  fully-typed modernized `cement generate` templates.
+- "The human act of tagging is the source of truth" — the agent's job is to
+  make that act zero-risk (verified SHA, green pre-checks, exact commands),
+  not to perform it.
+- Announcement copy should read from the finalized changelog highlights, not
+  be written fresh — one source of truth for what shipped.
+
+</specifics>
+
+<deferred>
+## Deferred Ideas
+
+- Post-release checklist issue execution (GitBook docs, mailing list, Slack
+  sends) — human work that outlives the phase; tracked by the auto-created
+  issue, not by phase plans.
+- Milestone archive — user runs `/gsd-complete-milestone` in a separate
+  session after Phase 6 verifies (D-15).
+- Full-commit-SHA action pinning tightening for community actions — runbook
+  "known accepted tradeoffs" #2; revisit post-release if desired.
+
+### Reviewed Todos (not folded)
+- `2026-05-09-document-optional-features-in-gitbook-post-3-0-16.md` — GitBook
+  developer docs for ext.generate optional features (#778). Stays on the
+  emitted post-release checklist (05.4 D-16); blocked on the release itself.
+- `2026-07-11-update-gitbook-todo-tutorial-for-pdm-backend.md` — GitBook
+  todo-tutorial walkthrough update for pdm-backend. Same disposition:
+  post-release GitBook work on the emitted checklist.
+
+</deferred>
+
+---
+
+*Phase: 06-release-cut-3-0-16*
+*Context gathered: 2026-07-12*

--- a/.planning/phases/06-release-cut-3-0-16/06-DISCUSSION-LOG.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-DISCUSSION-LOG.md
@@ -1,0 +1,168 @@
+# Phase 6: Release Cut 3.0.16 - Discussion Log
+
+> **Audit trail only.** Do not use as input to planning, research, or execution agents.
+> Decisions are captured in CONTEXT.md — this log preserves the alternatives considered.
+
+**Date:** 2026-07-12
+**Phase:** 6-release-cut-3-0-16
+**Areas discussed:** Changelog finalization, Release-prep commit flow, Provisioning completion, Post-release wrap-up scope
+
+---
+
+## Todo Cross-Reference (pre-discussion)
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Keep both deferred | GitBook todos stay on the auto-emitted post-release checklist issue (05.4 D-16) | ✓ |
+| Fold #778 GitBook features doc | Make it a tracked Phase 6 deliverable | |
+| Fold todo-tutorial GitBook update | Make it a tracked Phase 6 deliverable | |
+
+**User's choice:** Keep both deferred (recommended).
+
+---
+
+## Changelog finalization
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Full git-log cross-check | Diff `git log 3.0.14..HEAD` against every entry; flag missing user-visible changes and stale entries | ✓ |
+| Light structural pass | Trust phase-by-phase maintenance; verify buckets + formatting only | |
+| You decide | Claude picks audit depth during planning | |
+
+**User's choice:** Full git-log cross-check.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Pure buckets | Match 3.0.x convention exactly — no prose intro | |
+| Add highlights paragraph | 2–4 sentence intro summarizing release themes above the buckets; also tops the GitHub Release body | ✓ |
+
+**User's choice:** Add highlights paragraph — deviates from the recommended pure-bucket convention; user wants the narrative summary.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Condense verbose entries | Keep every entry, edit to 1–3 lines at release-notes altitude | ✓ |
+| Preserve entries as-is | Only audit completeness + formatting | |
+| Condense + trim dev-only entries | Also fold `[dev]` tooling entries into consolidated lines | |
+
+**User's choice:** Condense verbose entries (keep all entries, including `[dev]`).
+
+---
+
+## Release-prep commit flow
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| One release-prep PR | Single branch: changelog finalization + VERSION bump; user merges; merge commit gets tagged | ✓ |
+| Two PRs: changelog, then bump | Isolate the subjective edit from the mechanical one | |
+| Direct to main with consent | Skip PR overhead with explicit authorization | |
+
+**User's choice:** One release-prep PR.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, final dry-run | `workflow_dispatch` against the merged release commit; validates preflight against real finalized changelog + version; D-08 skip-existing caveat accepted | ✓ |
+| No, tag directly | CI-04 dry-run already green; preflight failure is cheap (delete/re-tag) | |
+
+**User's choice:** Yes, final dry-run.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| You push it yourself | Agent hands over verified commands; human act of tagging stays the source of truth (05.4 D-01) | ✓ |
+| Agent pushes at a checkpoint | Executor tags/pushes after explicit approval | |
+
+**User's choice:** User pushes the tag personally.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Re-run failed jobs | GitHub re-run-failed-jobs on the same run; tag stays; manual fallback only if unrecoverable | ✓ |
+| Manual completion | Finish downstream steps by hand after any post-PyPI failure | |
+| You decide | Claude picks per-job recovery during planning | |
+
+**User's choice:** Re-run failed jobs (gate failures remain delete/re-tag per 05.4 D-01).
+
+---
+
+## Provisioning completion
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Guided checkpoint session | Agent walks the runbook item-by-item; user clicks provider UIs; agent verifies via gh api where possible | ✓ |
+| I'll do it offline | User completes runbook solo and confirms | |
+| Hybrid | Agent configures everything CLI-reachable; only provider-UI items go to the user | |
+
+**User's choice:** Guided checkpoint session.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| You run it, agent preps | Agent hands exact `-s ours` merge + push commands; user executes on main | ✓ |
+| Agent runs it with consent | One-time authorized direct push to main by the agent | |
+| PR merged via merge-commit | Preserves ancestry only if the merge method isn't rebase/squash | |
+
+**User's choice:** User runs the ancestry merge; agent preps and verifies.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Maintainer PAT | Simplest; full account scope | |
+| Bot-account PAT | Machine account with repo-only push rights | |
+| Org access token (OAT) | Repo-scoped org token; requires Docker Team/Business | ✓ |
+| Decide during provisioning | Pick at the checkpoint in the Docker Hub UI | |
+
+**User's choice:** Org access token (OAT) — deviates from the maintainer-PAT recommendation; fallback per runbook §4 if the org plan doesn't support OAT.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| First plan of the phase | Full checklist up front; surprises surface earliest | ✓ |
+| Parallel with changelog work | Sibling plans in the same wave | |
+| Just-in-time before tag | Provisioning as the last step pre-tag | |
+
+**User's choice:** First plan of the phase.
+
+---
+
+## Post-release wrap-up scope
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Through dev-bump merge | Publish + Release live + dev-bump PR merged + requirement flips + VERIFICATION.md | ✓ |
+| End at publish | Dev-bump merge and flips as post-phase housekeeping | |
+| Include post-release checklist | Phase open until GitBook/notifications done | |
+
+**User's choice:** Through dev-bump merge.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Single clean-venv check | One venv, pip install from PyPI, import + App().run() round-trip | ✓ |
+| Full 5-Python matrix | Repeat on 3.10–3.14 docker legs against production PyPI | |
+
+**User's choice:** Single clean-venv check.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Yes, draft the copy | Agent drafts announcement from finalized changelog; sending stays human | ✓ |
+| No, fully human | Announcements entirely in the user's voice | |
+
+**User's choice:** Yes, draft the announcement copy.
+
+| Option | Description | Selected |
+|--------|-------------|----------|
+| Separate session | Phase ends at flips + VERIFICATION.md; user invokes /gsd-complete-milestone later | ✓ |
+| Chain it into the phase | Hand directly into milestone completion | |
+
+**User's choice:** Separate session.
+
+---
+
+## Claude's Discretion
+
+- Plan/wave decomposition beyond provisioning-first
+- Git-log cross-check mechanics (commit classification, planning-artifact filtering)
+- Condensed-entry wording and highlights paragraph (reviewed via the release-prep PR)
+- Announcement-copy format and artifact location
+- Dry-run/live-run monitoring cadence during execution
+
+## Deferred Ideas
+
+- Post-release checklist issue execution (GitBook docs, mailing list, Slack) — human work tracked by the auto-created issue
+- Milestone archive via `/gsd-complete-milestone` — separate follow-up session
+- Full-commit-SHA pinning for community actions — runbook accepted-tradeoff #2, revisit post-release
+- Reviewed todos not folded: `2026-05-09-document-optional-features-in-gitbook-post-3-0-16.md`, `2026-07-11-update-gitbook-todo-tutorial-for-pdm-backend.md` (both post-release GitBook work)

--- a/.planning/phases/06-release-cut-3-0-16/06-PATTERNS.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-PATTERNS.md
@@ -1,0 +1,252 @@
+# Phase 6: Release Cut 3.0.16 - Pattern Map
+
+**Mapped:** 2026-07-12
+**Files analyzed:** 5 (2 source edits, 1 runbook checkoff, 2 GSD artifacts)
+**Analogs found:** 4 / 5 (announcement copy has no in-repo analog — first automated release)
+
+> **Phase character:** This phase RUNS pre-built release machinery; it authors
+> almost no code. The only executable source edits are a one-line VERSION tuple
+> bump and CHANGELOG.md finalization. "Analogs" here are therefore prior release
+> conventions (previous CHANGELOG sections, the version tuple's own shape, prior
+> `*-VERIFICATION.md` reports) — not controllers/services/components. The planner
+> should treat "copy the pattern" literally: match the established header/tuple
+> forms byte-for-byte, because downstream automation parses them.
+
+## File Classification
+
+| New/Modified File | Role | Data Flow | Closest Analog | Match Quality |
+|-------------------|------|-----------|----------------|---------------|
+| `cement/core/backend.py` | config (version-of-record) | transform (bump) | `scripts/bump_dev_version.py` `_render_backend()` + current tuple | exact |
+| `CHANGELOG.md` | doc (release notes, parsed by CI) | transform (finalize) | `## 3.0.14 - May 5, 2025` section | exact |
+| `.planning/.../05.4-PROVISIONING.md` (checkoff) | runbook | request-response (verify + check off) | `05.4-05-SUMMARY.md` checkpoint pattern | role-match |
+| `.planning/.../06-VERIFICATION.md` | GSD artifact | batch (requirement flip + evidence) | `05.4-VERIFICATION.md` | exact |
+| `.planning/.../06-ANNOUNCEMENT.md` (or similar) | doc (announcement copy) | transform (derive from changelog) | — | no analog |
+
+## Pattern Assignments
+
+### `cement/core/backend.py` (config / version-of-record, transform)
+
+**Analog:** the file's own current single line + `scripts/bump_dev_version.py`
+regex that rewrites it (do NOT run the script — hand-edit; Pitfall 2).
+
+**Current state** (`cement/core/backend.py` line 3 — the ENTIRE file is 3 lines):
+```python
+"""Cement core backend module."""
+
+VERSION = (3, 0, 15, 'final', 0)  # pragma: nocover  # version constant
+```
+
+**Target edit** (change the third tuple element ONLY; preserve the trailing
+pragma + comment exactly — the script and mypy both depend on this shape):
+```python
+VERSION = (3, 0, 16, 'final', 0)  # pragma: nocover  # version constant
+```
+
+**Single-source-of-truth invariant** (RESEARCH REL-01): `pyproject.toml` reads
+this via `[tool.pdm.version] source="call" getter="cement.utils.version:get_version"`
+and `cement/__init__.py` re-exports `get_version()`. Do NOT edit those. Verify
+after the edit:
+```bash
+grep -rn "3\.0\.15\|(3, 0, 15" --include="*.py" --include="*.toml" . | grep -v ".planning/"
+# expect ONLY scripts/bump_dev_version.py's regex-doc comment (not a version of record)
+python -c "from cement.utils.version import get_version; print(get_version())"  # -> 3.0.16
+```
+
+**Why hand-edit, not `bump_dev_version.py`** (Pitfall 2): the script forces
+`'final'` (correct) but ALSO prepends a fresh `## X.Y.Z - DEVELOPMENT` changelog
+section — wrong for a release-prep PR that FINALIZES an existing section. Reserve
+the script for the post-release 3.0.17 bump, which the `dev-bump` workflow job
+runs (not the planner).
+
+---
+
+### `CHANGELOG.md` (doc parsed by CI, transform / finalize)
+
+**Analog:** the `## 3.0.14 - May 5, 2025` finalized section (CHANGELOG.md
+lines 541-564) — the canonical shape a finalized section takes.
+
+**Header finalization** (D-02) — the CURRENT unfinalized header at line 3:
+```markdown
+## 3.0.15 - DEVELOPMENT (will be released as stable/3.0.16)
+```
+becomes (MUST begin exactly `## 3.0.16` — `release.yml`'s `gh-release` job
+awk-extracts the section by `## <tag>` match, and preflight rejects a header
+still containing `DEVELOPMENT`):
+```markdown
+## 3.0.16 - July 12, 2026
+```
+Date format copies the established convention verbatim: `## 3.0.14 - May 5, 2025`.
+
+**Bucket structure** (already present in the 3.0.15 section — preserve all five,
+in this order; keep even empty ones as prior sections do with `- None`):
+```
+Bugs:          (CHANGELOG.md line 5)
+Features:      (line 209)
+Refactoring:   (line 287)
+Misc:          (line 462)
+Deprecations:  (line 536)
+```
+
+**Highlights paragraph** (D-03) — NEW element with no prior analog in the
+changelog (previous sections have no narrative intro). Insert a 2-4 sentence
+paragraph BETWEEN the `## 3.0.16 - <date>` header and the first `Bugs:` bucket.
+Themes are locked by CONTEXT specifics: Python 3.10-3.14 matrix, warn-only
+deprecations with 3.2.0 removals signposted, automated release workflow,
+fully-typed modernized `cement generate` templates. This paragraph becomes the
+top of the GitHub Release body and the source for the announcement copy (D-14).
+
+**Entry condensation** (D-04) — copy the altitude of the 3.0.14 entries (1-3
+lines, release-notes voice), NOT the verbose dev-forensic style of the current
+3.0.15 entries. Example of the target altitude (from the 3.0.14 section):
+```markdown
+- `[ext_jinja2]` Refactor hard-coded reference to `jinja2` template handler.
+  - [Issue #749](https://github.com/datafolklabs/cement/issues/749)
+```
+Contrast with a current 3.0.15 entry to be condensed (CHANGELOG.md lines 24-28):
+```markdown
+- `[utils.fs]` Restore `os.path` semantics in `abspath()` —
+  preserves symlink paths and silently falls through on unknown
+  `~user` prefixes (regression introduced by the Phase 03 Wave 6
+  pathlib migration; restores 3.0.x BC contract on the public
+  `cement.utils.fs:abspath` surface)
+```
+Rule (D-04): keep EVERY entry (including `[dev]` entries — do NOT delete/merge),
+edit each to 1-3 lines. The `[area]` prefix convention (`[core.foundation]`,
+`[ext.smtp]`, `[cli]`, `[dev]`) is already correct throughout — preserve it.
+
+**D-01 cross-check mechanics** (reconcile, not rewrite): diff
+`git log 3.0.14..HEAD` against the populated buckets, filtering planning-artifact
+commits per CLAUDE.md "Changelog Maintenance" rules (drop `docs(NN.N):`,
+`docs(state):`, `docs(quick-...):`; filter revert-pairs/overwrites; bucket by
+Conventional Commit type: `fix:`→Bugs, `feat:`→Features, `refactor:`→Refactoring,
+`chore:`→Misc). The section is already fully populated — this is a completeness
+audit against success criterion 1, gated by the release-prep PR review.
+
+---
+
+### `.planning/.../05.4-PROVISIONING.md` (runbook checkoff, request-response)
+
+**Analog:** the checkpoint/human-verify pattern from `05.4-05-SUMMARY.md`
+(provisioning confirmed via checkpoint) — reused by D-09's guided session.
+
+**Pattern:** for each pre-first-tag checklist item, the agent (a) presents the
+exact provider value, (b) the user clicks through the provider UI, (c) the agent
+verifies via `gh api`/`git` where verifiable and checks the item off in the
+runbook. Verifiable-from-here commands already proven this session:
+```bash
+gh api repos/datafolklabs/cement/environments/release   # reviewer present
+gh api repos/datafolklabs/cement/actions/secrets        # DOCKERHUB_* currently absent
+git merge-base --is-ancestor origin/stable/3.0.x main && echo FF-OK  # ancestry
+```
+This file is only lightly edited (checkbox state); it is NOT rewritten.
+
+---
+
+### `.planning/.../06-VERIFICATION.md` (GSD artifact, batch)
+
+**Analog:** `.planning/phases/05.4-github-actions-release-workflow/05.4-VERIFICATION.md`
+— same phase family (a release-machinery verification that flips requirement IDs).
+
+**YAML frontmatter shape** (05.4-VERIFICATION.md lines 1-27) — copy this block
+structure exactly (fields: `phase`, `verified` ISO8601, `status`, `score`,
+`behavior_unverified`, `overrides_applied`, `overrides[]`, `re_verification`,
+`gaps[]`, `deferred[]`, `human_verification[]`):
+```yaml
+---
+phase: 06-release-cut-3-0-16
+verified: <ISO8601>
+status: passed
+score: 7/7 must-haves verified
+behavior_unverified: 0
+overrides_applied: 0
+overrides: []
+re_verification: null
+gaps: []
+deferred:
+  - truth: "..."
+    addressed_in: "..."
+    evidence: "..."
+human_verification: []
+---
+```
+
+**Body sections** (copy 05.4's headings): `## Goal Achievement` →
+`### Observable Truths (ROADMAP Success Criteria)` table (`# | Truth | Status |
+Evidence`), `### Required Artifacts`, `### Key Link Verification`,
+`### Behavioral Spot-Checks / Probe Execution`, `### Requirements Coverage`
+(the table that flips REL-01..05 / CI-04 / DOCS-03 from Pending→Complete with
+evidence), `### Anti-Patterns Found`, `### Human Verification Required`,
+`### Gaps Summary`.
+
+**Requirements-coverage row pattern** (05.4-VERIFICATION.md lines 92-100 —
+copy this evidence-citation style; Phase 6 turns each `SATISFIED (machinery)`
+into a live-run `SATISFIED` with a run-id/`gh release view`/clean-venv proof):
+```markdown
+| REL-04 | 04 | PyPI publish; installs cleanly 3.10-3.14 | ✓ SATISFIED (machinery) | ... |
+```
+
+---
+
+### `.planning/.../06-ANNOUNCEMENT.md` (announcement copy) — NO ANALOG
+
+**Reason:** this is the FIRST automated release; no prior announcement artifact
+exists in `.planning/`. The planner should NOT invent fresh prose — per D-14 and
+the "Don't Hand-Roll" table, DERIVE the copy from the finalized CHANGELOG.md
+highlights paragraph (D-03), keeping one source of truth for "what shipped".
+Format and location are Claude's discretion (CONTEXT). Sending stays human
+(05.4 D-15). See "No Analog Found" below.
+
+## Shared Patterns
+
+### Conventional Commits + 78-char wrap (all commits this phase)
+**Source:** CLAUDE.md "Commit Conventions"
+**Apply to:** the release-prep PR commit(s), the `-s ours` ancestry merge message,
+planning-artifact commits (`docs(06):` prefix).
+```
+chore: record stable/3.0.x ancestry for release fast-forward   # D-10 merge msg
+docs(06): <planning artifact>                                  # planning commits
+```
+Subject max 78 chars; body wrapped at 78.
+
+### Branching policy — no direct commits to main
+**Source:** CLAUDE.md "Branching Policy"; CONTEXT D-05
+**Apply to:** all executable changes. The changelog finalization + VERSION bump
+ride ONE release-prep PR (branch e.g. `gsd/phase-6-release-cut`); the user
+reviews and merges; the merged main commit is what gets tagged. The lone
+exception is the `-s ours` ancestry merge (D-10), which MUST land as a real merge
+commit run directly on main by the USER (a squash/rebase PR would destroy the
+second parent — Pitfall 1), not via a squashed PR.
+
+### Quality gates hold green (release-prep PR)
+**Source:** CLAUDE.md "Key Development Practices"; RESEARCH Validation Architecture
+**Apply to:** the release-prep PR before merge.
+```bash
+make comply        # ruff + mypy
+make test          # 100% coverage (needs Redis:6379 + memcached:11211 — MEMORY note)
+make audit-public-api   # byte-for-byte green (Phase 3 D-04 lineage)
+```
+Full PR CI (`gates.yml` via `build_and_test.yml`) must be green before merge.
+
+### `[area]` changelog entry prefix
+**Source:** CLAUDE.md "Changelog Maintenance"; existing CHANGELOG.md entries
+**Apply to:** every CHANGELOG.md entry — one line, prefixed `[area]`
+(`[ext.smtp]`, `[cli]`, `[core.handler]`, `[dev]`). Already correct in the
+3.0.15 section; preserve during condensation.
+
+## No Analog Found
+
+| File | Role | Data Flow | Reason |
+|------|------|-----------|--------|
+| `.planning/.../06-ANNOUNCEMENT.md` | doc (announcement copy) | transform | First automated release — no prior announcement draft exists in the repo. Per D-14 / "Don't Hand-Roll", derive from the finalized CHANGELOG highlights paragraph (D-03) rather than pattern-matching an analog. Format/location are Claude's discretion. |
+
+Note: the changelog **highlights paragraph** (D-03) is also a first — previous
+CHANGELOG sections have no narrative intro. It has no in-repo analog; the four
+locked themes (CONTEXT specifics) are the content spec.
+
+## Metadata
+
+**Analog search scope:** `CHANGELOG.md` (section conventions),
+`cement/core/backend.py`, `scripts/bump_dev_version.py`, `.planning/phases/**`
+(`*-VERIFICATION.md`, `05.4-PROVISIONING.md`, `05.4-05-SUMMARY.md`).
+**Files scanned:** ~8 (2 source, 1 script, 5 planning artifacts).
+**Pattern extraction date:** 2026-07-12

--- a/.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-RESEARCH.md
@@ -1,0 +1,450 @@
+# Phase 6: Release Cut 3.0.16 - Research
+
+**Researched:** 2026-07-12
+**Domain:** Software release engineering — running a pre-built GitHub Actions release pipeline (PyPI OIDC publish, Docker Hub multi-arch, RTD, GitHub Release) for a strict-backward-compat Python library
+**Confidence:** HIGH (machinery + live provisioning state directly inspected; only provider-UI trusted-publisher/RTD state is unverifiable from here)
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+
+**Changelog finalization**
+- **D-01:** Full git-log cross-check before finalization — diff `git log 3.0.14..HEAD` against every entry in the `## 3.0.15 - DEVELOPMENT` section; flag any user-visible change missing and any entry that no longer matches what shipped.
+- **D-02:** Section header renamed to `## 3.0.16 - <Month D, YYYY>` matching the convention (`## 3.0.14 - May 5, 2025`). MUST begin `## 3.0.16` — the `gh-release` job awk-extracts by tag match; preflight (05.4 D-02) validates finalization.
+- **D-03:** Add a short narrative highlights paragraph (2–4 sentences) at the top of the 3.0.16 section — Python 3.10–3.14 matrix, warn-only deprecations, release automation, template modernization — above the standard buckets. Becomes the top of the GitHub Release body.
+- **D-04:** Condense verbose entries: keep EVERY entry, edit each to 1–3 lines at release-notes altitude. Drop dev-time forensic detail (git retains it). Do NOT delete or merge `[dev]` entries.
+
+**Release-prep commit flow**
+- **D-05:** One release-prep PR: single branch carries changelog finalization + `cement/core/backend.py` VERSION bump to `(3, 0, 16, 'final', 0)`. User reviews and merges; the merged main commit is what gets tagged. No direct commits to main.
+- **D-06:** One final `workflow_dispatch` dry-run against the merged release commit on main before tagging. Accepted caveat (05.4 D-08): the dry-run uploads 3.0.16 to TestPyPI; the real tag run skip-exists and smokes that same artifact.
+- **D-07:** The USER pushes the tag personally (`git tag 3.0.16 && git push origin 3.0.16`). Agent hands over the exact verified command sequence (correct SHA, pre-tag ancestry check already proven green).
+- **D-08:** Failure policy for the live run: gate failures = delete tag, fix, re-tag. Publish-side partial failure AFTER PyPI publish succeeds (Docker, branch-sync, gh-release, dev-bump): use GitHub re-run-failed-jobs on the same run — tag stays.
+
+**Provisioning completion**
+- **D-09:** Guided checkpoint session as the FIRST plan of the phase — walk `05.4-PROVISIONING.md`'s pre-first-tag checklist item-by-item; agent presents exact values, user clicks through provider UIs, agent verifies each via `gh api`/repo state where verifiable.
+- **D-10:** The one-time `stable/3.0.x` ancestry merge (`git merge -s ours`) is run by the USER on main; agent preps the exact command sequence and verifies `merge-base --is-ancestor` afterward. Must be a real merge commit — a rebase/squash-merged PR would destroy the merge parent and branch-sync would fail.
+- **D-11:** Docker Hub credentials via an org access token (OAT) on the `datafolklabs` org — repo-scoped. Requires Docker Team/Business; if OAT is unavailable at the checkpoint, fall back per runbook §4 (bot-account PAT preferred over maintainer PAT).
+
+**Post-release wrap-up scope**
+- **D-12:** Phase end = through dev-bump merge: PyPI + Docker + GitHub Release live, dev-bump PR merged (VERSION `(3, 0, 17, ...)` + fresh `## 3.0.17 - DEVELOPMENT`), and REL-01..05 / CI-04 / DOCS-03 flipped with a VERIFICATION.md.
+- **D-13:** REL-04 verification is a single clean-venv check: `pip install cement==3.0.16` from production PyPI + import + minimal `App().run()` round-trip. The 5-Python matrix already proved the identical artifact from TestPyPI inside the release run.
+- **D-14:** The phase drafts the release announcement copy (highlights-based, from the finalized changelog) as a small artifact the user can paste. Sending remains human (05.4 D-15).
+- **D-15:** Milestone completion is a separate follow-up session — Phase 6 ends at requirement flips + VERIFICATION.md; user invokes `/gsd-complete-milestone` afterward.
+
+### Claude's Discretion
+- Exact plan/wave decomposition (provisioning-first is locked; the rest may parallelize where file ownership allows).
+- Mechanics of the git-log cross-check (commit classification, filtering planning-artifact commits per CLAUDE.md changelog rules).
+- Shape/wording of the condensed changelog entries and the highlights paragraph (user reviews via the release-prep PR).
+- Announcement-copy format and where the draft artifact lives.
+- How dry-run/live-run monitoring is reported back during execution (checkpoint cadence while the ~30–40 min runs are in flight).
+
+### Deferred Ideas (OUT OF SCOPE)
+- Post-release checklist issue execution (GitBook docs, mailing list, Slack sends) — human work tracked by the auto-created issue, not by phase plans.
+- Milestone archive — user runs `/gsd-complete-milestone` in a separate session (D-15).
+- Full-commit-SHA action pinning tightening for community actions — runbook "known accepted tradeoffs" #2; revisit post-release.
+- GitBook todos `2026-05-09-document-optional-features...` and `2026-07-11-update-gitbook-todo-tutorial...` — post-release GitBook work on the emitted checklist.
+</user_constraints>
+
+<phase_requirements>
+## Phase Requirements
+
+| ID | Description | Research Support |
+|----|-------------|------------------|
+| DOCS-03 | Changelog updated for 3.0.16 with all user-visible changes | D-01 git-log cross-check against the existing `## 3.0.15` section (Bugs L3, Features L207, Refactoring L285, Misc L460, Deprecations L534); D-02 header rename; D-03/D-04 condensation. Preflight's finalized-changelog guard + `gh-release` awk extraction enforce it at tag time. |
+| CI-04 | Release workflow validated end-to-end against TestPyPI before the cut | Already GREEN once (dry-run [29212487225](https://github.com/datafolklabs/cement/actions/runs/29212487225), `conclusion: success`, `event: workflow_dispatch`). D-06 re-runs one final dry-run against the *finalized* 3.0.16 commit. |
+| REL-01 | Version bumped to 3.0.16 across all version-of-record locations | **Single source of truth = `cement/core/backend.py` VERSION tuple.** `pyproject.toml` `version` is `dynamic` via `[tool.pdm.version] source="call" getter="cement.utils.version:get_version"`; `cement/__init__.py` imports `get_version` dynamically. Editing backend.py alone satisfies REL-01. |
+| REL-02 | Pre-release TestPyPI smoke passes on each supported Python | `testpypi-smoke` matrix job (3.10–3.14) runs `scripts/testpypi-smoke.py` = install plain zero-dep `cement==X.Y.Z` + import `App` + `App().run()` round-trip + version assert. Proven green on all 5 legs in the dry-run. |
+| REL-03 | 3.0.16 git tag + GitHub Release notes published with changelog | Tag push (D-07, human) triggers `release.yml`; `gh-release` job awk-extracts the `## 3.0.16` section → `RELEASE_BODY.md` → `gh release create`. |
+| REL-04 | PyPI publish; installs cleanly on 3.10–3.14 | `publish-pypi` OIDC job (env `release`, no `skip-existing` — duplicate fails loud). D-13 verifies with one clean-venv `pip install cement==3.0.16` from prod PyPI. |
+| REL-05 | Post-release version bumped to 3.0.17 | `dev-bump` job runs `scripts/bump_dev_version.py` (next = released patch+1, computed) → PR via `create-pull-request`. Phase merges that PR (D-12). |
+</phase_requirements>
+
+## Summary
+
+Phase 6 does **not build software — it runs a machine that is already built and validated.** Phase 05.4 delivered `.github/workflows/release.yml` (13 jobs), `gates.yml`, and three helper scripts, and proved the pre-publish half end-to-end with a green `workflow_dispatch` dry-run ([run 29212487225](https://github.com/datafolklabs/cement/actions/runs/29212487225)). The only executable code changes this phase should expect are (1) the CHANGELOG finalization and (2) the one-line `VERSION` tuple bump — both in a single release-prep PR. Everything else is provisioning-in-provider-UIs, monitoring runs, and a human tag push.
+
+The dominant risk is **not code — it is external, provider-UI state that cannot live in git and cannot be fully verified from this machine.** The research therefore front-loads a live inventory of provisioning state (below). As of 2026-07-12 the picture is: `release`/`testpypi` GitHub Environments exist and `release` has the required reviewer; Actions-can-open-PRs is on; the TestPyPI trusted publisher works (dry-run proved it). **Two blocking items are still open:** the Docker Hub secrets (`DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`) are **not set**, and `stable/3.0.x` is **not yet an ancestor of `main`** (the `-s ours` reconcile has not landed). Two items — the **PyPI trusted publisher** and the **RTD GitHub integration** — cannot be verified from here and must be confirmed in the D-09 guided session.
+
+A second important finding de-risks REL-01: despite the requirement wording ("across `cement/__init__.py`, `pyproject.toml`, and any other version-of-record locations"), Cement has a **single version of record** — the `VERSION` tuple in `cement/core/backend.py`. `pyproject.toml` reads it dynamically via PDM `source="call"`, and `cement/__init__.py` re-exports `get_version()`. There is exactly one place to edit; a repo-wide grep for `3.0.15`/`(3, 0, 15` finds only `backend.py` (and the regex-doc line in `bump_dev_version.py`, which is a comment, not a version of record).
+
+**Primary recommendation:** Sequence the phase as five plans — (1) **provisioning checkpoint** (D-09, close the two open blockers + confirm PyPI/RTD in the UI); (2) **release-prep PR** (changelog D-01..D-04 + `backend.py` bump, review+merge); (3) **final dry-run** (D-06) against the merged commit; (4) **tag handoff + live-run shepherding** (D-07/D-08, human tag + approval gate); (5) **post-release verification + wrap-up** (D-13 clean-venv check, merge dev-bump PR, announcement draft, requirement flips + VERIFICATION.md). Do provisioning first because it has zero code dependencies and surfaces provider surprises earliest.
+
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|-------------|----------------|-----------|
+| Version of record (bump to 3.0.16 / 3.0.17) | Source (`cement/core/backend.py`) | Build (`pyproject.toml` reads it via PDM `source="call"`) | Single tuple; everything else derives. |
+| Changelog authoring | Source (`CHANGELOG.md`) | CI (preflight guard reads it; `gh-release` extracts it) | Human-authored text that the pipeline treats as data. |
+| Trigger (the release "start button") | Human + Git (tag push) | CI (`on: push: tags`) | D-07: the human act of tagging is the source of truth. |
+| Gate enforcement | CI (`gates.yml` via `release.yml`) | — | Test matrix, coverage, ruff/mypy, cli-smoke — fail-fast before any publish. |
+| Artifact build | CI (`build` job, `pdm build`) | — | Isolated from all publish credentials; hands identical bytes downstream. |
+| PyPI / TestPyPI publish | External registry (PyPI OIDC) | CI (`id-token: write` + env claim) | Trusted-publisher auth; no long-lived tokens in repo. |
+| Docker images | External registry (Docker Hub) | CI (`docker` job + secret login) | No OIDC on Docker Hub → scoped access-token secret. |
+| Docs rebuild | External service (Read the Docs) | Git (`3.0` moving-tag push fires RTD webhook) | RTD builds per minor line off the `3.0` moving tag. |
+| Branch/tag sync | Git refs (`stable/3.0.x`, `3`, `3.0`) | CI (`branch-sync`/`tag-sync` jobs) | Fast-forward branch; force-update moving tags. |
+| Approval gate | Human (GitHub `release` Environment) | CI (all publish jobs `needs: publish-pypi`) | The one and only manual stop. |
+
+## Release Execution Flow
+
+```
+                      ┌─────────────────── PHASE 6 HUMAN/AGENT WORK ────────────────────┐
+ (D-09) Provisioning checkpoint  ──►  (D-05) Release-prep PR   ──►  (D-06) Final dry-run
+   • DOCKERHUB_* secrets              • CHANGELOG finalize          • workflow_dispatch on
+   • -s ours ancestry merge (D-10)      (D-01..D-04)                  merged 3.0.16 commit
+   • confirm PyPI trusted publisher   • backend.py VERSION bump     • uploads 3.0.16 to
+   • confirm RTD integration          • review + MERGE to main        TestPyPI (first time)
+                                                                    • 5-Python smoke green
+                                                    │
+                                                    ▼
+ (D-07) HUMAN pushes tag  git tag 3.0.16 && git push origin 3.0.16
+                                                    │
+                                                    ▼
+ ┌──────────────────────────── release.yml (on: push tag 3.*.* ) ───────────────────────────┐
+ │ preflight ─► gates(full matrix) ─► build(pdm) ─► testpypi-publish ─► testpypi-smoke(3.10–14)│
+ │                                                                          │                  │
+ │                                                    ══ APPROVAL GATE ══   ▼                  │
+ │                                              publish-pypi  [environment: release]  ◄── HUMAN │
+ │                                                            │  (D-04 single stop)             │
+ │            ┌───────────┬───────────┬────────────┬─────────┴──────────┬────────────────┐     │
+ │            ▼           ▼           ▼            ▼                     ▼                ▼     │
+ │         docker    branch-sync   tag-sync    gh-release           dev-bump      post-release  │
+ │       (multi-arch  (FF stable/  (force 3,3.0 (RELEASE_BODY   (PR: 3.0.17 +   -checklist       │
+ │        push)        3.0.x)       → RTD)       from awk)       fresh CHANGELOG)  (issue)        │
+ └───────────────────────────────────────────────────────────────────────────────────────────┘
+                                                    │
+                                                    ▼
+ (D-13) POST-RELEASE  clean-venv pip install cement==3.0.16 + App().run()  ──►  merge dev-bump PR
+                                                    │                              ──►  announcement draft (D-14)
+                                                    ▼                              ──►  flip REL-01..05/CI-04/DOCS-03
+                                             06-VERIFICATION.md                    ──►  (D-15 milestone = separate session)
+```
+[CITED: .github/workflows/release.yml, 05.4-PROVISIONING.md]
+
+## Standard Stack
+
+No new packages. This phase uses tools already present in the repo and dev environment.
+
+### Core (all already installed / in-workflow)
+| Tool | Version | Purpose | Why Standard |
+|------|---------|---------|--------------|
+| `git` | system | Tag push (D-07), `-s ours` ancestry merge (D-10), ancestry checks | The tag push IS the release trigger. |
+| `gh` (GitHub CLI) | system | Provisioning verification (`gh api`), run monitoring (`gh run view/watch`), release inspection | Repo CLAUDE.md standardizes on `gh` for GitHub ops. [VERIFIED: gh api calls succeeded this session] |
+| `pdm` | present | `pdm build` (in-workflow), dependency mgmt | Project build backend (pdm-backend). |
+| `pypa/gh-action-pypi-publish` | `@v1.14.0` | OIDC publish to TestPyPI + PyPI | Pinned in `release.yml`. [CITED: release.yml L131,L205] |
+| `peter-evans/create-pull-request` | `@v8.1.1` | dev-bump PR | Pinned in `release.yml` L345. |
+| `docker/build-push-action` | `@v7.3.0` | Multi-arch (amd64+arm64) image push | Pinned in `release.yml` L229. |
+
+### Supporting (in-repo helper scripts — do not modify unless a bug surfaces)
+| Script | Purpose | When Used |
+|--------|---------|-----------|
+| `scripts/testpypi-smoke.py` | Install+import+`App().run()`+version-assert from TestPyPI | `testpypi-smoke` matrix job (dry-run + real run) |
+| `scripts/bump_dev_version.py` | Rewrite VERSION tuple + prepend `## 3.0.17 - DEVELOPMENT` | `dev-bump` job (post-release) |
+| `scripts/cli-smoke-native.py` | Cross-OS CLI smoke | Currently commented out in `gates.yml` (deferred to backlog 999.2) |
+
+### Alternatives Considered
+| Instead of | Could Use | Tradeoff |
+|------------|-----------|----------|
+| Editing `backend.py` VERSION by hand for the 3.0.16 bump | Running `bump_dev_version.py` | The script forces `'final'` too, but it also **prepends a fresh DEVELOPMENT changelog section** — wrong for the release-prep PR (which finalizes, not opens, a section). Hand-edit the tuple for 3.0.16; let the script handle only the 3.0.17 dev bump inside the workflow. |
+| `gh run watch` for live monitoring | Polling `gh run view --json` | `watch` blocks; `--json status,conclusion,jobs` polling fits the checkpoint-cadence reporting the user asked for (D-16 discretion). |
+
+## Package Legitimacy Audit
+
+**Not applicable — this phase installs no new packages.** The release-prep PR touches only `CHANGELOG.md` and `cement/core/backend.py`; no `pyproject.toml` dependency changes, no new dev-deps. The GitHub Actions consumed by the pipeline were already audited and pinned in Phase 05.4 (see `05.4-SECURITY.md`, `threats_open: 0`; runbook "known accepted tradeoffs" #2 covers the exact-tag vs full-SHA pin posture for the three community actions: `peter-evans/create-pull-request@v8.1.1`, `hoverkraft-tech/compose-action@v3.0.0`, `ConorMacBride/install-package@v1.1.0`). No legitimacy gate to run. [CITED: 05.4-PROVISIONING.md "Known accepted tradeoffs"]
+
+## Provisioning State Inventory (LIVE, 2026-07-12)
+
+> The highest-value research output. Every item verifiable from here was checked with `gh api`/`git` this session; provider-UI-only items are flagged for the D-09 session.
+
+| # | Checklist item | State (live check) | Blocking for | Action in Phase 6 |
+|---|----------------|--------------------|--------------|-------------------|
+| 1 | GitHub Environment `release` with required reviewers | ✅ EXISTS, reviewer `derks` [VERIFIED: gh api environments/release] | approval gate | none — confirm in D-09 |
+| 2 | GitHub Environment `testpypi` | ✅ EXISTS (no branch policy) [VERIFIED: gh api] | dry-run | optional hardening only |
+| 3 | TestPyPI trusted publisher (repo/`release.yml`/env `testpypi`) | ✅ WORKS — dry-run 29212487225 published + smoked green [VERIFIED: gh run] | dry-run | none |
+| 4 | "Allow GitHub Actions to create and approve PRs" | ✅ ON (`can_approve_pull_request_reviews: true`) [VERIFIED: gh api] | dev-bump PR | none |
+| 5 | `stable/3.0.x` unprotected / bot can push | ✅ Not protected; classic protection 404 [VERIFIED: gh api] | branch-sync | none (re-check if rules added) |
+| 6 | Tag ruleset allows bot to force-update `3`/`3.0` | ⚠️ Ruleset "Github Actions Release Force Tags" is **active**, targets `refs/tags/3` + `refs/tags/3.0`, rule = **`deletion` only**, **no bypass actors** [VERIFIED: gh api rulesets/18840408] | tag-sync | **VERIFY on first run** — see Pitfall 4 |
+| 7 | **Docker Hub secrets `DOCKERHUB_USERNAME` + `DOCKERHUB_TOKEN`** | ❌ **NOT SET** — repo secrets list is empty [VERIFIED: gh api actions/secrets] | `docker` job | **CLOSE in D-09** (D-11 OAT path) |
+| 8 | **`stable/3.0.x` is an ancestor of `main`** (`-s ours` reconcile) | ❌ **NOT AN ANCESTOR** — `merge-base --is-ancestor` fails [VERIFIED: git] | branch-sync | **USER runs `-s ours` merge (D-10)**, agent verifies |
+| 9 | **PyPI trusted publisher** (repo/`release.yml`/env `release`) | ❓ UNVERIFIABLE from here (PyPI provider UI) | `publish-pypi` (real) | **CONFIRM in D-09** before tag push |
+| 10 | **RTD GitHub integration** connected; no per-patch activation rule | ❓ UNVERIFIABLE from here (RTD provider UI) | docs rebuild | **CONFIRM in D-09** |
+| 11 | CHANGELOG finalized (`## 3.0.16 - <date>`, not DEVELOPMENT) | ❌ Still `## 3.0.15 - DEVELOPMENT (will be released as stable/3.0.16)` [VERIFIED: file] | preflight (push) | D-05 release-prep PR |
+| 12 | `backend.py` VERSION == tag | ❌ Currently `(3, 0, 15, 'final', 0)` [VERIFIED: file] | preflight (push) | D-05 release-prep PR |
+
+**Net:** 6 items green, 2 hard blockers open (#7 Docker secrets, #8 ancestry merge), 2 provider-UI unverifiable (#9 PyPI publisher, #10 RTD), 1 to verify-on-run (#6 tag ruleset), 2 closed by the release-prep PR (#11/#12).
+
+## Runtime State Inventory
+
+> This is a release/version-migration phase — external and ref state matters more than code.
+
+| Category | Items Found | Action Required |
+|----------|-------------|------------------|
+| Stored data | None — Cement has no datastores; the release is stateless artifacts. Verified: no DB/collection/key state in scope. | none |
+| Live service config (provider UI, NOT in git) | GitHub Environments (`release`+reviewer, `testpypi`) ✅; TestPyPI trusted publisher ✅; **PyPI trusted publisher ❓**; **Docker Hub secrets ❌ not set**; **RTD GitHub integration ❓**; tag ruleset "Force Tags" ⚠️ | Close Docker secrets (D-11); confirm PyPI publisher + RTD in D-09; verify tag ruleset does not block force-update |
+| OS-registered state | None (no scheduled tasks / daemons involved) | none |
+| Secrets/env vars | `DOCKERHUB_USERNAME`, `DOCKERHUB_TOKEN` (repo secrets) — **not set**. PyPI/TestPyPI use OIDC → **no PyPI token secret exists by design** (do not create one). | Set the two Docker secrets only |
+| Build artifacts / registry state | TestPyPI currently holds `cement 3.0.15` (from dry-run 29212487225, which derives version from the package — currently 3.0.15). 3.0.16 is **not yet on TestPyPI**. `*.egg-info/` locally is stale after any version edit. PyPI has ≤3.0.14. | D-06 dry-run uploads 3.0.16 to TestPyPI fresh; the real tag run `skip-existing` re-smokes it. Rebuild local env (`make init`) if egg-info drifts. |
+
+**The canonical question — "after the repo is updated, what still holds old state?":** TestPyPI's immutable-filename index. Once 3.0.16 is uploaded (by the D-06 dry-run), it is frozen; the real run's `--skip-existing` re-uses those exact bytes (05.4 D-08 accepted caveat — same commit, no drift). A version-string mistake in the release-prep PR that reaches TestPyPI **cannot be overwritten** for that version number — it can only be superseded by a bump. This is why the final dry-run runs against the *merged, finalized* commit, not a WIP branch.
+
+## Don't Hand-Roll
+
+| Problem | Don't Build | Use Instead | Why |
+|---------|-------------|-------------|-----|
+| Bumping the version | A sed/manual multi-file edit hunting `pyproject.toml` + `__init__.py` | Edit the ONE `VERSION` tuple in `cement/core/backend.py` | pyproject/`__init__` derive dynamically; extra edits would create a false second source of truth. |
+| Post-release 3.0.17 bump | Hand-editing after release | The `dev-bump` job (`bump_dev_version.py`) inside the workflow | Already computed (patch+1), already tested, opens the PR. Phase just merges it. |
+| Extracting release notes from CHANGELOG | Copy-paste into GitHub Release UI | The `gh-release` job's awk extraction | Deterministic `## 3.0.16` section boundary; zero human transcription error. |
+| Re-pointing `3`/`3.0` moving tags + RTD rebuild | Manual `git push --force` + RTD UI click | `tag-sync` job (fires RTD webhook) | The whole point of Phase 05.4; manual steps are what it replaced. |
+| PyPI auth | Adding a `PYPI_TOKEN` secret | OIDC trusted publisher (already the design) | Long-lived tokens are the exact anti-pattern 05.4 removed; adding one is a regression. |
+| Announcement copy | Writing fresh prose | Derive from the finalized changelog highlights paragraph (D-03) | One source of truth for "what shipped" (D-14 / specifics). |
+
+**Key insight:** Nearly every "release step" you might reflexively hand-roll is already a workflow job. Phase 6's job is to *feed the machine correct inputs* (finalized changelog + correct version + provisioned providers) and *press the human buttons* (merge, tag, approve, merge). Re-implementing any automated step is scope creep and a regression risk.
+
+## Common Pitfalls
+
+### Pitfall 1: Squash/rebase-merging the ancestry reconcile (D-10) — silently breaks branch-sync
+**What goes wrong:** The `-s ours` merge must land on `main` as a **real merge commit** with `origin/stable/3.0.x` as a parent. If the user merges it via a GitHub PR with "Squash" or "Rebase", the second parent is destroyed and `stable/3.0.x` is *still* not an ancestor — `branch-sync` fails on the live release.
+**Why it happens:** GitHub's default PR merge button is often squash; the ancestry link is invisible in a diff (`-s ours` changes no files).
+**How to avoid:** Run the merge directly on `main` locally per runbook §6b (`git merge -s ours origin/stable/3.0.x -m "..."` then `git push origin main`), NOT via a squashed PR. Agent verifies with `git merge-base --is-ancestor origin/stable/3.0.x main && echo FF-OK` afterward. [CITED: 05.4-PROVISIONING.md §6b, D-10]
+
+### Pitfall 2: Running `bump_dev_version.py` for the 3.0.16 bump
+**What goes wrong:** The helper sets `'final'` (good) BUT also prepends a new `## 3.0.16 - DEVELOPMENT` section. In the release-prep PR you are *finalizing* the existing section to `## 3.0.16 - <date>`, not opening a new one — running the script would create a duplicate/DEVELOPMENT-marked header that fails preflight's finalization guard.
+**How to avoid:** For the release-prep PR, hand-edit the `VERSION` tuple `(3, 0, 15, ...) → (3, 0, 16, 'final', 0)` and finalize the changelog header manually. Reserve `bump_dev_version.py` for the automated 3.0.17 bump (which the workflow runs, not you). [CITED: bump_dev_version.py docstring L88-106]
+
+### Pitfall 3: TestPyPI immutability — a bad version can't be re-uploaded
+**What goes wrong:** If the D-06 dry-run runs against a commit with a wrong version or unfinalized changelog and uploads to TestPyPI, that filename is frozen. Re-running won't refresh it (`skip-existing`).
+**How to avoid:** Run the D-06 dry-run ONLY after the release-prep PR is merged to main (finalized changelog + correct VERSION). The dry-run's version is derived from the package, so it will be exactly 3.0.16. [CITED: release.yml preflight L62-70; 05.4-PROVISIONING.md §3 stale-upload caveat]
+
+### Pitfall 4: The "Force Tags" ruleset could block `tag-sync`
+**What goes wrong:** A GitHub tag ruleset covering `refs/tags/3` and `refs/tags/3.0` exists and is **active with no bypass actors**. If it enforced `non_fast_forward` or `update`, the `tag-sync` job's `git push --force` would be rejected and the docs rebuild would never fire.
+**Why it (probably) does NOT block:** The ruleset's only rule is **`deletion`**. A moving-tag force-update is a non-fast-forward *update*, not a deletion, so `deletion` does not apply. [VERIFIED: gh api rulesets/18840408 — rules=["deletion"], target=tag, no bypass]
+**How to avoid / verify:** On the first live release, confirm `tag-sync` succeeds. If it fails with a protected-ref error, add the **GitHub Actions** app to the ruleset's bypass list (Settings → Rules → Rulesets). Flag this in the D-09 checkpoint as "verify-on-run."
+
+### Pitfall 5: Docker Hub login with a password / OAT-plan surprise (D-11)
+**What goes wrong:** The `docker` job needs `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` (currently unset). Using an account password (not a token), or discovering the org lacks a Docker Team/Business plan for the preferred OAT, blocks the multi-arch push.
+**How to avoid:** In D-09, mint the token per runbook §4 preference order: **OAT (org-scoped)** → **bot-account PAT** → **maintainer PAT**. With an OAT, `DOCKERHUB_USERNAME` = `datafolklabs` (the org name), not a personal login. The `docker` job runs *after* the approval gate, so a Docker misconfig does NOT block the PyPI publish — but per D-08 it would need a re-run-failed-jobs. Close this before tagging. [CITED: 05.4-PROVISIONING.md §4, D-11]
+
+### Pitfall 6: Approving the gate before the changelog is truly complete (DOCS-03 / success criterion 1)
+**What goes wrong:** Preflight only checks the section is *finalized* (not `- DEVELOPMENT`); it does NOT check that every user-visible change is *enumerated*. A missing entry passes CI but violates success criterion 1, and the GitHub Release body (auto-extracted) ships incomplete.
+**How to avoid:** The D-01 git-log cross-check (`git log 3.0.14..HEAD`, filter planning-artifact commits per CLAUDE.md changelog rules) is the only guard. 360 commits are in range but the section already has full buckets; the cross-check is a reconcile, not a rewrite. Do it before merging the release-prep PR — the PR review is the human gate. [CITED: D-01; CLAUDE.md "Changelog Maintenance"]
+
+### Pitfall 7: The dev-bump PR shows zero CI checks (accepted, not a bug)
+**What goes wrong:** The `dev-bump` PR is authored by `GITHUB_TOKEN`; GitHub's anti-recursion rule means `on: pull_request` CI does not fire, so the PR shows no checks. A reviewer might block on "missing CI."
+**How to avoid:** This is accepted tradeoff #1 in the runbook — merge it deliberately (main CI runs post-merge). Don't wait for checks that will never appear. [CITED: 05.4-PROVISIONING.md "Known accepted tradeoffs" #1]
+
+## Code Examples
+
+Exact, verified command sequences the plans will use.
+
+### Version bump (release-prep PR) — single source of truth
+```python
+# cement/core/backend.py  (edit the tuple ONLY; preserve the trailing pragma comment)
+VERSION = (3, 0, 16, 'final', 0)  # pragma: nocover  # version constant
+```
+```bash
+# Verify the whole repo has no other 3.0.15 version-of-record (expect only the
+# bump_dev_version.py regex-doc comment, which is not a version of record):
+grep -rn "3\.0\.15\|(3, 0, 15" --include="*.py" --include="*.toml" . | grep -v ".planning/"
+# Confirm the derived version after the edit:
+python -c "from cement.utils.version import get_version; print(get_version())"   # -> 3.0.16
+```
+[VERIFIED: grep this session found only backend.py + bump_dev_version.py comment]
+
+### Changelog header finalization (D-02)
+```markdown
+## 3.0.16 - July 12, 2026   <!-- convention matches: `## 3.0.14 - May 5, 2025` -->
+```
+[VERIFIED: CHANGELOG.md L541 header convention]
+
+### One-time ancestry reconcile (D-10 — USER runs on main, NOT via squashed PR)
+```bash
+git fetch origin main stable/3.0.x
+git switch main && git pull --ff-only origin main
+git merge -s ours origin/stable/3.0.x \
+  -m "chore: record stable/3.0.x ancestry for release fast-forward"
+git diff HEAD^ HEAD            # MUST print nothing (zero content change)
+git push origin main
+git merge-base --is-ancestor origin/stable/3.0.x main && echo FF-OK   # agent verifies
+```
+[CITED: 05.4-PROVISIONING.md §6b]
+
+### Final dry-run (D-06 — after release-prep PR merged)
+```bash
+gh workflow run release.yml -R datafolklabs/cement --ref main
+# then monitor:
+gh run list -R datafolklabs/cement --workflow release.yml --limit 1
+gh run view <run-id> -R datafolklabs/cement --json status,conclusion,jobs
+```
+
+### Pre-tag safety + tag handoff (D-07 — commands the AGENT hands to the USER)
+```bash
+# 1. resolve the exact SHA to tag (the merged release-prep commit on main):
+git fetch origin main && git rev-parse origin/main
+# 2. prove the fast-forward precondition BEFORE tagging (must print FF-OK):
+git merge-base --is-ancestor origin/stable/3.0.x <sha> && echo FF-OK
+# 3. USER pushes the tag (this is the release trigger):
+git tag 3.0.16 <sha>
+git push origin 3.0.16
+```
+[CITED: release.yml trigger L10-11; D-07]
+
+### Live-run monitoring + approval
+```bash
+gh run watch <run-id> -R datafolklabs/cement            # or poll --json as above
+# approval happens in the GitHub UI: Actions → run → "Review deployments" → approve `release`
+```
+
+### REL-04 clean-venv verification (D-13 — after PyPI publish)
+```bash
+python -m venv /tmp/cement-rel-check && . /tmp/cement-rel-check/bin/activate
+pip install cement==3.0.16
+python -c "from cement import App; from cement.utils.version import get_version; \
+  assert get_version()=='3.0.16', get_version(); \
+  App(argv=[]).run() if False else None; print('REL-04 OK', get_version())"
+deactivate
+```
+(Mirror `scripts/testpypi-smoke.py`'s `SmokeApp(argv=[])` pattern for a real `App().run()` round-trip if desired.) [CITED: testpypi-smoke.py L88-99; D-13]
+
+### Failure recovery (D-08)
+```bash
+# Gate/preflight failure BEFORE publish → delete tag, fix, re-tag:
+git push --delete origin 3.0.16 && git tag -d 3.0.16
+# ... fix on a branch, merge, re-tag ...
+# Publish-side partial failure AFTER PyPI publish succeeded → re-run failed jobs (tag stays):
+gh run rerun <run-id> -R datafolklabs/cement --failed
+```
+[CITED: D-08]
+
+## State of the Art
+
+| Old Approach (issue #791) | Current Approach (Phase 05.4) | When Changed | Impact |
+|---------------------------|-------------------------------|--------------|--------|
+| Manual release checklist, hand-run twine + docker + tags | Tag-push-triggered `release.yml` | 2026-07-12 | Phase 6 is the first real exercise of the automation |
+| Long-lived PyPI API token | OIDC trusted publisher (`id-token: write` + env claim) | 05.4 | No token secret to leak; do NOT add one |
+| Manual `3`/`3.0` tag re-point + RTD click | `tag-sync` job fires RTD webhook | 05.4 | RTD rebuilds `/en/3.0/` automatically |
+| Manual post-release version bump | `dev-bump` job opens the 3.0.17 PR | 05.4 | Phase only merges the PR |
+
+**Deprecated/outdated within this repo context:**
+- Travis CI — deleted in Phase 1; GitHub Actions is the only CI.
+- Any per-patch RTD activation rule — explicitly must NOT exist (RTD is per-minor-line off `3.0`). [CITED: 05.4-PROVISIONING.md §5]
+
+## Environment Availability
+
+| Dependency | Required By | Available | Version | Fallback |
+|------------|------------|-----------|---------|----------|
+| `git` | Tag push, ancestry merge | ✅ | system | — |
+| `gh` CLI (authenticated to datafolklabs) | Provisioning verify + run monitoring | ✅ | authenticated (gh api succeeded) | — |
+| `python`/`pdm` dev env | Local version verify, REL-04 clean venv | ✅ | 3.10+ | `make init` rebuilds if broken |
+| PyPI trusted publisher | `publish-pypi` (real) | ❓ provider-UI | — | Confirm/create in D-09 — BLOCKING for real publish |
+| Docker Hub token secrets | `docker` job | ❌ not set | — | Mint OAT/PAT in D-09 (D-11) — post-gate, so re-runnable |
+| RTD GitHub integration | docs rebuild | ❓ provider-UI | — | Confirm in D-09; fallback = manual RTD build trigger |
+
+**Missing dependencies with no fallback (must resolve before tag push):**
+- PyPI trusted publisher (item #9) — a missing/misconfigured publisher fails the real `publish-pypi` with `invalid-publisher` at the approval gate.
+- `stable/3.0.x` ancestry (item #8) — `branch-sync` fails without the `-s ours` merge.
+
+**Missing dependencies with viable in-run recovery:**
+- Docker secrets (item #7) — `docker` runs after the gate; a failure is recoverable via re-run-failed-jobs once secrets are set (D-08), though best practice is to set them in D-09 before tagging.
+
+## Validation Architecture
+
+### Test Framework
+| Property | Value |
+|----------|-------|
+| Framework | `pytest` + `pytest-cov` (100% coverage gate, `--cov-fail-under=100`) |
+| Config file | `pyproject.toml` `[tool.pytest.ini_options]` |
+| Quick run command | `make comply` (ruff + mypy) |
+| Full suite command | `make test` (needs Redis:6379 + memcached:11211 up — MEMORY note) |
+
+### Phase Requirements → Validation Map
+| Req ID | Behavior | Validation Type | Command / Evidence | Exists? |
+|--------|----------|-----------------|--------------------|---------|
+| DOCS-03 | Changelog enumerates all user-visible changes | manual + preflight guard | D-01 cross-check; `grep "^## 3.0.16" CHANGELOG.md` (no `DEVELOPMENT`) | ✅ (preflight job) |
+| REL-01 | VERSION reads 3.0.16 | automated | `python -c "from cement.utils.version import get_version; print(get_version())"` == 3.0.16 | ✅ |
+| REL-02 | TestPyPI 5-Python smoke | automated (in-workflow) | `testpypi-smoke` matrix 3.10–3.14 green | ✅ |
+| CI-04 | Workflow end-to-end vs TestPyPI | automated (in-workflow) | Green `workflow_dispatch` run (D-06) | ✅ |
+| REL-03 | Tag + Release published | automated (in-workflow) + inspect | `gh release view 3.0.16`; tag exists | ✅ |
+| REL-04 | PyPI installs on 3.10–3.14 | manual clean-venv (D-13) + in-run 5-Python proof | `pip install cement==3.0.16` round-trip | ✅ |
+| REL-05 | Bumped to 3.0.17 | automated (dev-bump) + merge | dev-bump PR merged; `get_version()` == 3.0.17 | ✅ |
+
+### Sampling Rate
+- **Release-prep PR:** full PR CI (`gates.yml` via `build_and_test.yml`) must be green before merge — `make comply` + `make test` + matrix.
+- **Pre-tag:** the D-06 dry-run is the gate for the finalized artifact.
+- **Post-release:** D-13 clean-venv check + `gh release view` + dev-bump merge.
+
+### Wave 0 Gaps
+- None — this phase writes no product code and needs no new tests. The existing 100%-coverage gate and the release workflow's own gate suite are the validation. The `05.4` Windows/macOS smoke legs remain deferred to backlog 999.2 (accepted override, not a Phase 6 concern).
+
+## Security Domain
+
+> Release-side threat modeling was completed in Phase 05.4 (`05.4-SECURITY.md`, `threats_open: 0`, 19/19 dispositioned). Phase 6 introduces no new attack surface — it consumes the audited pipeline. Only the release-execution-specific controls are restated here.
+
+| Concern | STRIDE | Control (already in place) |
+|---------|--------|---------------------------|
+| Credential exfiltration during build | Information Disclosure | Isolated `build` job holds no publish creds; artifacts handed downstream. [CITED: release.yml build job] |
+| PyPI publish auth | Spoofing / Elevation | OIDC trusted publisher + `release` environment claim — no long-lived token. **Do not add a PyPI token secret.** |
+| Unapproved publish | Elevation of Privilege | Single `release` env approval gate; all publish-side jobs `needs: publish-pypi`. |
+| Template injection via `github.ref_name` | Tampering | Passed via `env:`, never inline-spliced; regex-escaped in awk/grep. [CITED: release.yml L54-57, L293-301] |
+| Supply-chain (actions) | Tampering | Exact-tag pins (accepted tradeoff #2); full-SHA tightening deferred. |
+| Docker token blast radius | Info Disclosure | OAT repo-scoping preferred (D-11); token, never password. |
+
+**Phase-6-specific control:** confirm the Docker token is repo-scoped (OAT) or account-limited (bot) before storing it as a secret — a maintainer PAT (fallback) reaches every repo that account can write to.
+
+## Assumptions Log
+
+| # | Claim | Section | Risk if Wrong |
+|---|-------|---------|---------------|
+| A1 | PyPI trusted publisher for `cement` (repo `datafolklabs/cement`, workflow `release.yml`, env `release`) is configured | Provisioning #9 | `publish-pypi` fails `invalid-publisher` at the approval gate — the release stalls after gates pass. **Confirm in D-09.** |
+| A2 | RTD GitHub integration is connected and will rebuild `/en/3.0/` on the `3.0` tag push | Provisioning #10 | Docs silently don't rebuild; artifacts still ship. Lower severity; **confirm in D-09.** |
+| A3 | The "Force Tags" ruleset (deletion-only, no bypass) does NOT block a moving-tag force-*update* | Pitfall 4 | `tag-sync` fails; RTD rebuild doesn't fire. Recoverable via bypass-list edit + re-run. **Verify on first run.** |
+| A4 | The `datafolklabs` org has a Docker Team/Business plan enabling the preferred OAT (D-11) | Pitfall 5 | Fall back to bot-account PAT then maintainer PAT per runbook §4. Non-blocking (post-gate job). |
+| A5 | TestPyPI still holds only `cement 3.0.15` (not 3.0.16) from the last dry-run | Runtime State | If a prior 3.0.16 upload exists, the D-06 dry-run `skip-existing`s it and smokes stale bytes — but since it'd be the same finalized commit, no drift. Low risk. |
+| A6 | The 360-commit `3.0.14..HEAD` range maps cleanly onto the existing 5 changelog buckets after planning-artifact filtering | Pitfall 6 / D-01 | An omitted user-visible change violates success criterion 1. Mitigated by the cross-check being a reconcile of an already-populated section, gated by PR review. |
+
+## Open Questions
+
+1. **Is the PyPI (real) trusted publisher configured?**
+   - What we know: TestPyPI's works (dry-run proved it); the `release` env + reviewer exist.
+   - What's unclear: PyPI's provider UI can't be read from here.
+   - Recommendation: First verification in the D-09 checkpoint; if absent, create it (repo `datafolklabs/cement`, workflow `release.yml`, env `release`) before any tag push. This is the single highest-risk unknown.
+
+2. **Does the tag ruleset permit the bot's moving-tag force-update?**
+   - What we know: rule is `deletion` only, no bypass actors; force-update ≠ deletion.
+   - What's unclear: whether GitHub treats a lightweight-tag force-move as covered.
+   - Recommendation: mark `tag-sync` as "verify-on-run"; if it fails, add GitHub Actions to the ruleset bypass list and `gh run rerun --failed` (D-08).
+
+3. **OAT plan availability for Docker (D-11)?**
+   - What we know: OAT needs Team/Business; fallback chain is documented.
+   - Recommendation: determine the plan at the D-09 checkpoint; pick the highest-scoping token path available.
+
+4. **Monitoring cadence during the ~30–40 min runs (D-16 discretion)?**
+   - Recommendation: `gh run view --json status,conclusion,jobs` at each job-transition, report a one-line status to the user; pause for the approval gate (human action in the GitHub UI).
+
+## Sources
+
+### Primary (HIGH confidence — live-verified this session)
+- `gh api repos/datafolklabs/cement/environments`, `.../actions/secrets`, `.../actions/permissions/workflow`, `.../rulesets/18840408` — provisioning state (envs, empty secrets, PR-approval on, force-tags ruleset)
+- `git merge-base --is-ancestor origin/stable/3.0.x origin/main` — ancestry still NOT recorded
+- `git tag -l`, `git rev-list --count 3.0.14..HEAD` (360), `grep`/`sed` on `CHANGELOG.md` + `cement/core/backend.py` + `pyproject.toml`
+- `gh run view 29212487225` — green `workflow_dispatch` dry-run baseline (CI-04)
+- `.github/workflows/release.yml` (13 jobs), `.github/workflows/gates.yml`
+- `scripts/testpypi-smoke.py`, `scripts/bump_dev_version.py`, `cement/utils/version.py`
+
+### Secondary (HIGH — authored contract artifacts from Phase 05.4)
+- `.planning/phases/05.4-github-actions-release-workflow/05.4-PROVISIONING.md` (checklist, exact values, §4 Docker, §5 RTD, §6 ancestry)
+- `.planning/phases/05.4-.../05.4-VERIFICATION.md` (5/5, deferred items), `05.4-CONTEXT.md`, `05.4-SECURITY.md`
+- `.planning/phases/06-release-cut-3-0-16/06-CONTEXT.md`, `.planning/REQUIREMENTS.md`, `CLAUDE.md`
+
+### Provider-UI unverifiable (flagged for D-09)
+- PyPI trusted publisher state, RTD GitHub integration state
+
+## Metadata
+
+**Confidence breakdown:**
+- Standard stack / no new packages: HIGH — repo + workflow files inspected directly.
+- Provisioning inventory: HIGH for gh/git-verifiable items; the 2 provider-UI items (PyPI publisher, RTD) are explicitly ASSUMED and gated to D-09.
+- Version-of-record (single source): HIGH — grep + pyproject dynamic config confirmed.
+- Pitfalls: HIGH — each traces to a workflow line or runbook section.
+
+**Research date:** 2026-07-12
+**Valid until:** provisioning state is live-checked here; re-verify items #7/#8/#9/#10 at the start of the D-09 session (state may change as the user provisions). Workflow/version facts stable for the release window.

--- a/.planning/phases/06-release-cut-3-0-16/06-VALIDATION.md
+++ b/.planning/phases/06-release-cut-3-0-16/06-VALIDATION.md
@@ -1,0 +1,76 @@
+---
+phase: 6
+slug: release-cut-3-0-16
+status: draft
+nyquist_compliant: false
+wave_0_complete: false
+created: 2026-07-12
+---
+
+# Phase 6 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | {pytest 7.x / jest 29.x / vitest / go test / other} |
+| **Config file** | {path or "none — Wave 0 installs"} |
+| **Quick run command** | `{quick command}` |
+| **Full suite command** | `{full command}` |
+| **Estimated runtime** | ~{N} seconds |
+
+---
+
+## Sampling Rate
+
+- **After every task commit:** Run `{quick run command}`
+- **After every plan wave:** Run `{full suite command}`
+- **Before `/gsd-verify-work`:** Full suite must be green
+- **Max feedback latency:** {N} seconds
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| {N}-01-01 | 01 | 1 | REQ-{XX} | T-{N}-01 / — | {expected secure behavior or "N/A"} | unit | `{command}` | ✅ / ❌ W0 | ⬜ pending |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+- [ ] `{tests/test_file.py}` — stubs for REQ-{XX}
+- [ ] `{tests/conftest.py}` — shared fixtures
+- [ ] `{framework install}` — if no framework detected
+
+*If none: "Existing infrastructure covers all phase requirements."*
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| {behavior} | REQ-{XX} | {reason} | {steps} |
+
+*If none: "All phase behaviors have automated verification."*
+
+---
+
+## Validation Sign-Off
+
+- [ ] All tasks have `<automated>` verify or Wave 0 dependencies
+- [ ] Sampling continuity: no 3 consecutive tasks without automated verify
+- [ ] Wave 0 covers all MISSING references
+- [ ] No watch-mode flags
+- [ ] Feedback latency < {N}s
+- [ ] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** {pending / approved YYYY-MM-DD}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,541 +1,326 @@
 # ChangeLog
 
-## 3.0.15 - DEVELOPMENT (will be released as stable/3.0.16)
+## 3.0.16 - July 13, 2026
+
+This release modernizes Cement against the current Python ecosystem while
+holding the 3.0.x public API stable. Python 3.8 and 3.9 are dropped (EOL) and
+the supported matrix is now Python 3.10–3.14. Every deprecation in this release
+is warn-only, with removals signposted for 3.2.0 so downstream apps have a clear
+upgrade window. A new automated GitHub Actions release workflow replaces the
+manual release checklist, and the `cement generate` project and todo-tutorial
+templates are now fully typed, PEP 517-buildable, and green under `make comply`
+and `make test` out of the box.
 
 Bugs:
 
-- `[core.foundation]` Fix `extensions` config-override to honor
-  `Meta.config_section` when it differs from `Meta.label` (was silently
-  using `label`, mirroring the `template_dirs` fix from PR #760) —
-  resolves #777
-- `[ext.smtp]` Fix `timeout` passed as `local_hostname` in SMTP constructors
-- `[ext.smtp]` Fix stale variable reference in `_get_params` for per-message headers
-- `[ext.smtp]` Fix SMTP connection leak when send fails with an exception
-- `[ext.smtp]` Fix unconditional error log on every send (now only logs on errors)
-- `[ext.smtp]` Fix header encoding incorrectly affected by `body_encoding` setting
+- `[core]` Add an explicit `__all__` to `cement/__init__.py` so
+  `from cement import *` exports only the intended public surface (App,
+  TestApp, Interface, Handler, Controller, the framework exceptions, and
+  the documented helpers) instead of leaking every transitively imported
+  name — #756
+- `[core.foundation]` Honor `Meta.config_section` (not `Meta.label`) when
+  applying the `extensions` config override, mirroring the `template_dirs`
+  fix — resolves #777
+- `[ext.smtp]` Fix `timeout` being passed as `local_hostname` in the SMTP
+  constructors
+- `[ext.smtp]` Fix a stale variable reference in `_get_params` for
+  per-message headers
+- `[ext.smtp]` Fix an SMTP connection leak when a send fails with an
+  exception
+- `[ext.smtp]` Only log on send errors (was logging unconditionally on
+  every send)
+- `[ext.smtp]` Fix header encoding being incorrectly affected by the
+  `body_encoding` setting
 - `[cli]` Generated `cement generate project` output now builds under pip's
-  default PEP 517 isolation on Python 3.10+ — the legacy `setup.py` self-imported
-  the package being built, which fails inside isolated build envs
-- `[core.handler]` Resolve mypy union-attr false-positive in handler resolution
+  default PEP 517 isolation on Python 3.10+ (the legacy `setup.py`
+  self-imported the package being built, which fails in isolated build
+  envs)
+- `[core.handler]` Resolve a mypy union-attr false-positive in handler
+  resolution
 - `[ext.redis]` Resolve mypy union-attr/arg-type/misc errors surfaced by
-  redis 7 typing changes (sync client return-type unions)
-- `[ext.watchdog]` Drop now-unused `# type: ignore` comments on Observer
-  schedule/start/stop calls — watchdog 6 ships precise type stubs
-- `[utils.fs]` Restore `os.path` semantics in `abspath()` —
-  preserves symlink paths and silently falls through on unknown
-  `~user` prefixes (regression introduced by the Phase 03 Wave 6
-  pathlib migration; restores 3.0.x BC contract on the public
-  `cement.utils.fs:abspath` surface)
-- `[dev]` Use explicit `encoding='utf-8'` in
-  `scripts/audit-public-api.py` so the
-  `make audit-public-api` regression gate is portable across
-  non-UTF-8 locales (Windows cp1252, locale-stripped Docker, etc.)
-- `[dev]` Fix `scripts/cli-smoke-test.sh` capturing the container's
-  `mktemp -d` path via `docker exec -t` — the pseudo-TTY made Docker
-  emit CRLF, and command substitution kept the trailing `\r`, so
-  every derived `$tmp/...` path carried an embedded carriage return
-  (`/tmp/tmp.XXXX\r/myapp/...`) and broke pdm/venv on the first
-  Python version. Drop `-t` on that one capture (the other `-t`
-  execs only feed `grep`, where a trailing `\r` is harmless)
-- `[dev]` Fix `scripts/cli-smoke-test.sh` `pdm install` of the
-  generated project failing to resolve the dev cement pin
-  (`cement==<unreleased>`) — `pdm install` resolves in a fresh
-  isolated venv against PyPI, where the in-development version is not
-  yet published, so it could not satisfy the exact pin. Inject a
-  find_links `[[tool.pdm.source]]` pointing at the mounted
-  `/src/dist` so the locally-built cement resolves. Harness-only
-  shim (real users install a published cement from PyPI); ruff/mypy/
-  pytest ignore the source table so the project gates are unaffected
-- `[core.interface]` Widen `InterfaceManager.get` `fallback`
-  parameter to `Any` to match the documented public contract and
-  the existing test that passes a string fallback (the parameter
-  was mechanically narrowed to `type[Interface] | None` by the
-  Phase 03 UP045 sweep; the runtime always accepted arbitrary
-  fallback values per the `cache.get` sibling pattern)
+  redis 7 typing changes
+- `[ext.watchdog]` Drop now-unused `# type: ignore` comments on the
+  Observer calls — watchdog 6 ships precise type stubs
+- `[utils.fs]` Restore `os.path` semantics in `abspath()` — preserve
+  symlink paths and fall through on unknown `~user` prefixes (regression
+  from the Phase 03 pathlib migration; restores the 3.0.x BC contract)
+- `[dev]` Use explicit `encoding='utf-8'` in `scripts/audit-public-api.py`
+  so the `make audit-public-api` gate is portable across non-UTF-8 locales
+- `[dev]` Fix `scripts/cli-smoke-test.sh` capturing a CRLF-tainted temp
+  path from `docker exec -t` that broke pdm/venv on the first Python
+  version (drop `-t` on that one capture)
+- `[dev]` Fix `scripts/cli-smoke-test.sh` `pdm install` failing to resolve
+  the unreleased dev cement pin by injecting a local find_links source
+  (`/src/dist`); harness-only, the project gates are unaffected
+- `[core.interface]` Widen the `InterfaceManager.get` `fallback` parameter
+  back to `Any` to match the documented contract (it was mechanically
+  narrowed by the Phase 03 UP045 sweep; the runtime always accepted
+  arbitrary fallback values)
 - `[ext.smtp]` Type the message body and `**params` correctly across
-  `SMTPMailHandler.send`, `_build_body_parts`, `_make_message`, and
-  the related private helpers (`_header`, `_build_charsets`,
-  `_build_mime_structure`, `_set_headers`, `_attach_body`,
-  `_attach_files`). Introduce a private `_BodyType =
-  str | tuple[str, str] | dict[str, str]` alias so the dict body
-  shape (`{'text': ..., 'html': ...}`), already supported at runtime
-  by `_build_body_parts`, is now reflected in the static type.
-  Convert seven `**params: dict[str, Any]` annotations to
-  `**params: Any` (the prior form declared each kwarg VALUE as a
-  dict, the wrong meta-type for var-kwargs); this lets callers pass
-  arbitrary keyword values per the documented contract. As a
-  follow-on cleanup, drop nine now-unused `# type: ignore`
-  suppressions at `params[...]` callsites that were papering over
-  the wrong meta-typing, and add a `part: MIMEBase` annotation in
-  `_attach_files` so the `MIMEImage`/`MIMEBase` branches type-check
-  cleanly. Public-API surface byte-identical (`_BodyType` is private
-  so `make audit-public-api` stays at exit 0)
-- `[utils.shell]` Correct `cmd` and `exec_cmd` return-type
-  annotations from `tuple[str, str, int]` to
-  `tuple[bytes, bytes, int]` (and `cmd`'s union return to
-  `tuple[bytes, bytes, int] | int`) — `subprocess.Popen` returns
-  `bytes` from `communicate()` by default, and the existing tests
-  already assert `out == b'KAPLA!\n'` (literal bytes). The prior
-  `str` annotation was a type/runtime mismatch that mypy could
-  not catch (the bytes return was bidirectionally compatible
-  with the declared `str` via `Any` upcasting in dependent
-  context). Docstrings updated to call out that `stdout`/
-  `stderr` are bytes and to point at `text=True` / `encoding=`
-  through `**kwargs` for callers wanting `str` output. Runtime
-  behavior unchanged; this is documentation/type honesty only,
-  not a behavior shift
-- `[utils.shell]` Correct `Prompt.Meta.options` annotation from
-  `dict | None` to `list[str] | None` — the runtime treats
-  `options` as a list of strings (iteration in
-  `Prompt._prompt`, `str.join` in the non-numbered branch,
-  integer indexing via `options[int(...) - 1]` in the numbered
-  branch, `in`-membership checks in the case-insensitive and
-  case-sensitive branches), all of which the prior `dict`
-  annotation actively misled. mypy didn't flag this previously
-  because `dict` without parameters resolves to
-  `dict[Any, Any]`, and `Any` silenced the type errors at every
-  callsite. All existing tests pass `options=['y', 'n']`-style
-  list literals, so the new concrete type matches actual usage
-- `[ext.yaml]` Replace implicit-Optional `template: str = None` on
-  `YamlOutputHandler.render()` with the explicit
-  `template: str | None = None` (PEP 484 / ruff RUF013), mirroring
-  the `[ext.mustache]` fix above. The handler ignores the
-  `template` parameter at runtime (per docstring), so no
-  follow-on `# type: ignore[arg-type]` was needed — the prior
-  signature-line `# type: ignore` is removed entirely. Public
-  signature byte-identical from the audit-public-api perspective.
-  Sister handlers (`ext.jinja2`, `ext.json`) carry the same
-  pattern and remain on the implicit-Optional form pending a
-  follow-up
-- `[ext.mustache]` Replace implicit-Optional `template: str = None`
-  on `MustacheOutputHandler.render()` with the explicit
-  `template: str | None = None` (PEP 484 / ruff RUF013). The
-  `# type: ignore` previously placed at the signature line is
-  removed (the implicit-Optional violation it was suppressing no
-  longer fires) and a scoped `# type: ignore[arg-type]` is added
-  at the `self.templater.load(template)` callsite to document
-  that the `None` default is well-defined at runtime
-  (`TemplateHandler.load` guards `if not template_path:` and
-  raises `FrameworkError`). Public signature byte-identical from
-  the audit-public-api perspective. Sister handlers
-  (`ext.jinja2`, `ext.yaml`, `ext.json`) carry the same pattern
-  and remain on the implicit-Optional form pending a follow-up
-- `[utils.misc]` Make `MinimalLogger.__init__` idempotent — guard
-  the `self.backend.addHandler(console)` call on
-  `not self.backend.handlers` so a second `minimal_logger(ns)`
-  call for the same namespace does not stack a duplicate
-  `StreamHandler` on the shared backend logger
-  (`logging.getLogger(ns)` returns the same instance per name, so
-  the previous unconditional add produced as many handlers as
-  callers — every log emit would print N times)
-- `[ext.daemon]` Remove the duplicate
-  `LOG = minimal_logger(__name__)` assignment at module scope
-  (a back-to-back redundant rebind that, combined with the prior
-  `MinimalLogger.__init__` non-idempotency, attached a second
-  `StreamHandler` to the `cement.ext.ext_daemon` backend logger
-  on import — covered by the `[utils.misc]` hardening above but
-  the redundant line is dropped for clarity)
-- `[core.template]` Replace fragile bare `assert` in
-  `TemplateHandler.copy()` source-path check with an explicit
-  `NotADirectoryError` raise. The previous code had two failure
-  modes: (1) bare `assert` is stripped under `python -O`/`-OO`,
-  so apps running cement under optimization lost the runtime check
-  entirely and `os.walk` would silently iterate over a
-  non-existent path; and (2) `Path.exists()` returned True for
-  files too, so passing a regular file as `src` made the assert
-  pass and `os.walk` yield nothing — silent no-op with no
-  diagnostic. The new check uses `is_dir()` (covers both missing
-  paths and non-directories in one branch) and raises
-  unconditionally regardless of optimization level.
-  **Behavioral compatibility note:** the exception type changes
-  from `AssertionError` to `NotADirectoryError`. Downstream code
-  catching `AssertionError` to detect a missing/invalid `src`
-  must switch to catching `NotADirectoryError` (or a parent like
-  `OSError`). Gating runtime contracts on `AssertionError` was
-  already fragile under `-O`, so this is a robustness fix
-  rather than a contract regression on a load-bearing surface.
-- `[core.interface]` String-quote list[str] return annotation for
+  `send`/`_make_message` and the related private helpers (new private
+  `_BodyType` alias reflects the dict body shape); drop nine now-unused
+  `# type: ignore` suppressions. Public API byte-identical
+- `[utils.shell]` Correct the `cmd`/`exec_cmd` return annotations from
+  `str` to `bytes` — `subprocess.Popen` returns bytes by default and the
+  existing tests assert byte literals; docstrings now point at
+  `text=True`/`encoding=` for `str` output (runtime unchanged)
+- `[utils.shell]` Correct the `Prompt.Meta.options` annotation from
+  `dict | None` to `list[str] | None` to match actual runtime usage
+- `[ext.yaml]` Use explicit `template: str | None = None` (PEP 484 /
+  RUF013) in `render()` and drop the signature-line `# type: ignore`
+- `[ext.mustache]` Use explicit `template: str | None = None` (PEP 484 /
+  RUF013) in `render()`; scope the remaining `# type: ignore` to the load
+  callsite
+- `[utils.misc]` Make `MinimalLogger.__init__` idempotent — guard the
+  console-handler add on `not self.backend.handlers` so repeated
+  `minimal_logger(ns)` calls no longer stack duplicate handlers (which
+  caused log output to repeat N times)
+- `[ext.daemon]` Remove a duplicate module-scope
+  `LOG = minimal_logger(__name__)` rebind
+- `[core.template]` Replace the fragile bare `assert` in
+  `TemplateHandler.copy()` with an explicit `NotADirectoryError` (the
+  assert was stripped under `python -O` and passed for regular files).
+  **Compatibility note:** the raised exception type changes from
+  `AssertionError` to `NotADirectoryError`
+- `[core.interface]` String-quote a `list[str]` return annotation for
   autodoc compatibility
-- `[core.deprecations]` Drop trailing period from the `3.0.10-1`
-  deprecation message — `deprecate()` appends `". See: ..."`, so a
-  pre-existing trailing period rendered as `..` in the runtime
-  warning. The other three entries already follow the implicit
-  no-trailing-period invariant
-- `[dev]` `make docs` zero-warnings gate now uses `&&` (was `;`),
-  so the recipe correctly fails on Sphinx warnings instead of
-  silently succeeding via the trailing `cd ..` exit code
-- `[ext.generate]` Fix `variables` default from `{}` to `[]` — the
-  generate flow iterates `variables` as a list of dicts, so the dict
-  default would have produced an empty key-iteration on templates
-  that omit the key
-- `[ext.generate]` Narrow the dynamic-template-module `except` from
-  bare `AttributeError` to `(AttributeError, ModuleNotFoundError)`
-  with a `name`-match guard, so transitive `ModuleNotFoundError`s
-  raised inside the user's template module propagate normally
-  instead of being silently swallowed as "module not found"
-- `[ext.generate]` `type: boolean` template variables now emit a real
-  Python bool at the top level of the render context (`data[name]`),
-  so `{% if feature_x %}` works in jinja2/mustache; the boolean prompt
-  uses a vars-style `[(Y)es/(N)o] [default]:` format and all variables
-  prompt in a single declaration-order pass — resolves #782 (the
-  former `features:` namespace and pre-pass are removed)
-- `[cli]` Generated `cement generate todo-tutorial` output now builds
-  under pip's default PEP 517 isolation on Python 3.10+ — the legacy
-  `setup.py` self-imported the package being built, which fails inside
-  isolated build envs (mirrors the `generate project` fix; #735)
-- `[cli]` Fix `NameError` in generated `todo/main.py` — the `TodoError`
-  handler referenced an undefined name; now `except TodoError as e:`
-  (#735)
-- `[cli]` Fix false-green assertion in the generated project test
-  template — `assert output.find(...)` (str.find() returns -1, which is
-  truthy, so it never fails) is now membership `assert '...' in output`,
-  so the test genuinely fails on wrong or empty rendered output (#735)
-- `[cli]` Generated todo-tutorial imports are now isort-clean and its
-  `[tool.ruff]` is scoped to the `todo/` package, so the shipped
-  `make comply` (ruff) is green out of the box (#735)
+- `[core.deprecations]` Drop a trailing period from the `3.0.10-1`
+  deprecation message (it rendered as `..` once `deprecate()` appended
+  its suffix)
+- `[dev]` `make docs` zero-warnings gate now uses `&&` (was `;`) so it
+  fails on Sphinx warnings
+- `[ext.generate]` Fix the `variables` default from `{}` to `[]` — the
+  generate flow iterates `variables` as a list of dicts
+- `[ext.generate]` Narrow the dynamic-template-module `except` to
+  `(AttributeError, ModuleNotFoundError)` with a name guard so transitive
+  import errors in a user's template module propagate normally
+- `[ext.generate]` `type: boolean` variables now emit a real Python bool
+  at the top level (`data[name]`) so `{% if feature_x %}` works; boolean
+  prompts use a vars-style `[(Y)es/(N)o]` format in a single
+  declaration-order pass — resolves #782 (the `features:` namespace is
+  removed)
+- `[cli]` Generated `cement generate todo-tutorial` output now builds under
+  PEP 517 isolation on Python 3.10+ (mirrors the `generate project` fix) —
+  #735
+- `[cli]` Fix a `NameError` in generated `todo/main.py` (now
+  `except TodoError as e:`) — #735
+- `[cli]` Fix a false-green assertion in the generated project test
+  template — a membership check replaces `str.find()`, which returned a
+  truthy `-1` and never failed — #735
+- `[cli]` Generated todo-tutorial imports are isort-clean and its
+  `[tool.ruff]` is scoped to `todo/`, so the shipped `make comply` is green
+  out of the box — #735
 - `[cli]` Constrain the cement dependency in generated `project` and
-  `todo-tutorial` templates to the backward-compatible 3.0.x stable line.
-  `project` previously used an exact `cement==<generating version>` pin,
-  which made a freshly generated project uninstallable whenever the
-  generating cement was an unreleased dev version (`pdm install` could not
-  resolve it from PyPI); it now renders a compatible-release range
-  (`cement[...]~={{ cement.major_version }}.{{ cement.minor_version }}.0`,
-  e.g. `~=3.0.0` → `>=3.0.0,<3.1`). `todo-tutorial` previously used an
-  uncapped `>=3.0`; it is now capped to a literal `>=3.0,<3.1` (that
-  template is copied verbatim, so it cannot use rendered version vars).
-  Both install any backward-compatible patch on the same stable minor
-  line (#735)
+  `todo-tutorial` templates to a compatible 3.0.x range (`~=3.0.0` /
+  `>=3.0,<3.1`) so freshly generated projects install even when generated
+  by an unreleased dev cement — #735
 
 Features:
 
 - `[core.foundation]` Support config override of `App.Meta.template_dirs`
-  via the `[<app>]` section. Accepts a list (under config handlers with
-  native list support, e.g. `ext_yaml` or `ext_json`) or a comma-separated
-  string (required for the default `ext_configparser` / INI handler).
-  String form is split + whitespace-trimmed, parallel to the existing
-  `extensions` config handling.
+  via the `[<app>]` section — accepts a list (native-list config handlers)
+  or a comma-separated string (the INI handler), parallel to the existing
+  `extensions` handling.
   - [Issue #746](https://github.com/datafolklabs/cement/issues/746)
-- `[ext.generate]` Add optional features support to generate templates
-  with conditional variables, exclude/ignore patterns, and dependency
-  resolution via `requires` (with transitive cascade when a required
-  feature is disabled). Resolution is order-independent — features may
-  declare `requires` against features defined later in the YAML.
+- `[ext.generate]` Add optional features support to generate templates —
+  conditional variables, exclude/ignore patterns, and order-independent
+  `requires` dependency resolution (with transitive cascade).
   - [Issue #743](https://github.com/datafolklabs/cement/issues/743)
 - `[ext.generate]` Add `prompt_mode: select` for multi-valued feature
-  prompts. A select-mode feature presents a numbered picker (delegated
-  to `cement.utils.shell.Prompt`) and dispatches the chosen value into
-  one of N `options` branches — each branch may declare its own
-  `ignore` / `exclude` / `variables` (incl. silent `prompt: false`
-  variables). `prompt_mode` defaults to `boolean` (legacy behavior,
-  byte-identical when key absent).
+  prompts — a numbered picker dispatching the chosen value into one of N
+  `options` branches, each with its own `ignore`/`exclude`/`variables`;
+  defaults to `boolean` (byte-identical when absent).
   - [Issue #779](https://github.com/datafolklabs/cement/issues/779)
 - `[ext.generate]` Add `type: choice` template variables — a numbered
-  `cement.utils.shell.Prompt` picker that emits the chosen option string
-  at the top level of the render context. `options:` accepts a scalar
-  list or per-option `{value, prompt}` objects; per-option effects live
-  in `extend:` rules keyed by `when: <value>`. Misconfig (empty options,
-  option missing `value`, default not in options, duplicate labels) is
-  fail-fast `ValueError`.
-- `[ext.generate]` `type: boolean` `prompt:` is now polymorphic —
-  in addition to the framework-owned string form and the silent
-  `prompt: false` form, an object form `{text, accept, reject}` lets the
-  template author own the full prompt text and supply case-insensitive
-  `accept:`/`reject:` token lists that map input to a real bool. Input
-  matching neither asserts and aborts (`Invalid Response`), mirroring
-  `validate:`. A bool-like `accept:`/`reject:` token that YAML 1.1
-  coerced to a Python bool raises `ValueError` telling the author to
-  quote it.
-- `[ext.generate]` `extend.when` now composes three match forms — a
-  scalar value (equality), an in-list membership (`when: [a, b]`), and a
-  string-type regex (`re.match`, string variables only) — and multiple
-  matching rules all fire, accumulating their `variables`/`exclude`/
-  `ignore`. `extend.variables` are nested and prompted depth-first in
-  place only when their parent rule fires. A new top-level `requires:`
-  key gates a variable using the same match vocabulary (`[name]` →
-  truthy, `{name: value}` → equality, `{name: [v1, v2]}` → in-list),
-  AND-ed across keys and resolved order-independently via lazy
-  recursion. A requires-gated-out variable is set to its `default` (so
-  templates never `KeyError`) and its `extend` rules do not fire. The
-  unified schema also addresses the PR #780 review feedback: features
-  prompt after vars in declaration order, with custom per-feature
-  prompt text and vars-style input.
+  picker that emits the chosen option string at the top level; `options:`
+  accepts scalars or `{value, prompt}` objects with per-option effects in
+  `extend:` rules; misconfig is fail-fast `ValueError`.
+- `[ext.generate]` `type: boolean` `prompt:` is now polymorphic — an object
+  form `{text, accept, reject}` lets the template author own the prompt
+  text and supply the token lists that map input to a real bool; unmatched
+  input aborts with `Invalid Response`.
+- `[ext.generate]` `extend.when` now composes scalar-equality, in-list
+  membership, and string-regex match forms (all matching rules fire) with
+  nested depth-first `extend.variables`; a new top-level `requires:` key
+  gates variables using the same vocabulary, AND-ed and resolved
+  order-independently, defaulting gated-out variables so templates never
+  `KeyError`. Also addresses the PR #780 review feedback (features prompt
+  after vars, custom prompt text, vars-style input).
   - [Issue #782](https://github.com/datafolklabs/cement/issues/782)
   - [PR #780](https://github.com/datafolklabs/cement/pull/780)
 - `[ext.argparse]` Add a read-only `_command_meta` property on
   `ArgparseController` so an exposed command can read its own `CommandMeta`
-  (label, `parser_options['help']`, etc.) from inside its body via
-  `self._command_meta`, replacing the brittle
-  `getattr(self, ...).__cement_meta__` dance. Returns `None` outside a
-  dispatched command and never raises. Additive — the `func()` dispatch
-  signature is unchanged.
+  from inside its body; returns `None` outside a dispatched command and
+  never raises. Additive — the `func()` dispatch signature is unchanged.
   - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
 - `[ext.argparse]` Add a companion read-only `_default_command_meta`
-  property on `ArgparseController` that resolves the controller's default
-  sub-command meta (via `Meta.default_func`), since `_command_meta` is
-  `None` while the default function runs (argparse has no native default
-  sub-command). Returns `None` when `default_func` is `None` or points to a
-  non-exposed function (e.g. the stock `_default`); never raises.
+  property that resolves the controller's default sub-command meta (via
+  `Meta.default_func`); returns `None` when there is no exposed default and
+  never raises.
   - [Issue #670](https://github.com/datafolklabs/cement/issues/670)
-- `[utils.misc]` Add optional `CEMENT_FRAMEWORK_LOG_FILE` env var — when
-  framework logging is enabled, framework/extension debug output is also
-  written to the given file (in addition to the console). Purely additive:
-  the variable alone does not enable logging, repeated calls do not stack
-  duplicate handlers, and an unwritable/invalid path is ignored rather
-  than raising.
+- `[utils.misc]` Add an optional `CEMENT_FRAMEWORK_LOG_FILE` env var — when
+  framework logging is enabled, debug output is also written to the given
+  file. Purely additive: no duplicate handlers on repeat calls, and an
+  invalid path is ignored rather than raising.
   - [Issue #593](https://github.com/datafolklabs/cement/issues/593)
 
 Refactoring:
 
-- `[ext.generate]` Remove the unreleased `features:` schema
-  (`prompt_mode`, `enabled:`/`disabled:` blocks, select `options:`
-  effects) wholesale — everything it expressed is now a `type:
-  boolean`/`type: choice` variable carrying `extend:`/`requires:`. The
-  legacy compatibility bridge is deleted; `features:` is no longer read
-  by the engine (#782).
-
+- `[ext.generate]` Remove the unreleased `features:` schema wholesale —
+  everything it expressed is now a `type: boolean`/`type: choice` variable
+  carrying `extend:`/`requires:`; the legacy compatibility bridge is
+  deleted (#782)
 - `[dev]` Migrate the `demo/generate-features/` webapp template to the
-  unified `type:`/`extend:`/`requires:` schema (off the removed
-  `features:` schema) and demonstrate the #782 fix — `{% if docker %}`
-  and `{% if web_framework == ... %}` now render against the top-level
-  bool/choice exposure
-- `[ext.smtp]` PEP 8 naming, idiomatic string methods, and cleaner type validation
+  unified `type:`/`extend:`/`requires:` schema and demonstrate the #782 fix
+  (top-level `{% if docker %}` / `{% if web_framework == ... %}`)
+- `[ext.smtp]` PEP 8 naming, idiomatic string methods, and cleaner type
+  validation
 - `[ext.smtp]` Refactor `_make_message` into focused private methods
 - `[ext.smtp]` Simplify X-header normalization and preserve original casing
-- `[dev]` Python 3.14 Default Development Target
-- `[dev]` Remove Support for Python 3.8 (EOL)
-- `[dev]` Remove Support for Python 3.9 (EOL)
-- `[cli]` Migrate `cement generate project` template from setuptools+setup.py
-  to pdm-backend with full PEP 621 metadata; deps moved to
-  `[project].dependencies` and `[dependency-groups].dev` (PEP 735); generated
-  `version.py` simplified to literal `__version__` + wrapper (no build-time
-  cement import)
-- `[cli]` Generated project `README.md` now documents system requirements
-  (Python 3.10+); end-user install uses `pip install .` / `pip install
-  <label>`; development section calls out PDM as an additional requirement
-  and uses `make setup` + `pdm run <label>`; generated `Makefile`
-  `virtualenv` target renamed to `setup` and reduced to `pdm install`
-  (drops redundant `pdm venv create` and the manual `eval $(pdm venv
-  activate)` hint)
-- `[core]` Modernize type annotations to PEP 585 builtin generics
-  (UP006: `List` → `list`, `Dict` → `dict`, `Tuple` → `tuple`,
-  `Type` → `type`); orphaned `typing` re-export imports pruned in the
-  same pass (F401)
-- `[core]` Modernize union types to PEP 604 syntax (UP007:
-  `Union[X, Y]` → `X | Y`); orphaned `typing.Union` imports pruned
+- `[dev]` Python 3.14 default development target
+- `[dev]` Remove support for Python 3.8 (EOL)
+- `[dev]` Remove support for Python 3.9 (EOL)
+- `[cli]` Migrate the `cement generate project` template from
+  setuptools+`setup.py` to pdm-backend with full PEP 621 metadata and PEP
+  735 dev deps; generated `version.py` no longer imports cement at build
+  time
+- `[cli]` Generated project `README.md`/`Makefile` now document Python
+  3.10+ and PDM, use `pip install .` for end users, and rename the
+  `virtualenv` target to `setup` (`pdm install`)
+- `[core]` Modernize type annotations to PEP 585 builtin generics (UP006:
+  `List`→`list`, `Dict`→`dict`, `Tuple`→`tuple`, `Type`→`type`); prune
+  orphaned `typing` re-exports
+- `[core]` Modernize union types to PEP 604 syntax (UP007: `Union[X, Y]`→
+  `X | Y`); prune orphaned `typing.Union` imports
 - `[core]` Modernize Optional types to PEP 604 syntax (UP045:
-  `Optional[X]` → `X | None`); orphaned `typing.Optional` imports
-  pruned
-- `[core]` Move `Callable` / `Generator` imports from `typing` to
-  `collections.abc` (UP035 — deprecated-import path).
-- `[core]` Convert printf-style format strings to modern format
-  (UP031 — `'%s' % x` → `f"{x}"` / `"{}".format(x)`). Protected
-  `.format(**template_dict)` template-substitution callsites in
-  cement/core/foundation.py preserved untouched per Phase 03 D-19.
-  REFACTOR-04 closeout.
-- `[core]` Drop redundant `(object)` base class (UP004); Python 3
-  classes inherit from object implicitly.
-- `[core]` Simplify `super()` calls (UP008 — drop `super(__class__,
-  self)` boilerplate; Python 3 zero-arg form).
-- `[core]` Drop redundant `'r'` mode argument from `open()` calls
-  (UP015 — `'r'` is the default).
-- `[core]` Replace `IOError` alias with `OSError` (UP024) in
-  cement/core/template.py — `IOError` is an alias since Python 3.3.
-- `[dev]` Drop legacy `u"..."` unicode literal prefix in test code
-  (UP025) — Python 3 strings are already Unicode.
-- `[dev]` Replace deprecated `mock` import with `unittest.mock`
-  (UP026) in tests/ext/test_ext_smtp.py + tests/utils/test_shell.py.
-- `[core]` Replace `for x in iterable: yield x` with `yield from`
-  (UP028) in cement/core/hook.py + tests/core/test_hook.py.
-- `[core]` Convert `.format()` calls to f-strings (UP032 cascade
-  surfaced after UP031). Protected `.format(**template_dict)`
-  template-substitution callsites in cement/core/foundation.py
-  preserved untouched (verified by body-diff against pre-fix state).
-  UP family fully clean after this commit.
-- `[core]` Tighten `Any` types in cement/core/ where narrower types are
-  provably correct; surviving Any carries inline justification per D-09
-  (delta: 41 → 40, 2 substantive tightenings — `App.__import__(obj: Any)`
-  → `obj: str` since the body always passes `obj` to stdlib `__import__`
-  against `alternative_module_mapping: dict[str, str]`; and
-  `ControllerInterface._dispatch() -> Any | None` → `-> Any` dropping
-  the redundant `| None` Wave 3 UP007 cascade artifact).
-- `[dev]` Refresh CONVENTIONS.md type-annotation guidance to
-  PEP 585 / PEP 604 modern syntax (Phase 03 plan 03 landing point).
-- `[core]` Wrap long log/error messages introduced by UP032 f-string
-  conversion to satisfy E501 (line-too-long); reorder imports
-  introduced by UP006/UP035 to satisfy I001 (import sorting).
-- `[core]` Drop `from __future__ import annotations` from all 29
-  files in cement/ (Phase 1 D-14 deferral closed). PEP 604/585
-  syntax (UP006/UP007/UP045 from the prior wave) is native in
-  Python 3.10+; the future-import is no longer needed. Forward
-  references to TYPE_CHECKING-bound names (App, FrameType,
-  ModuleType, TracebackType, ArgparseArgumentType,
-  ArgparseController) converted to PEP 484 string annotations
-  where evaluated at class/function definition time. Closes the
-  cement/utils/fs.py self-flagged 2024-06-22 TODO.
-- `[utils.fs]` Migrate `cement/utils/fs.py` os.path internals to
-  pathlib (Phase 03 D-11). Public functions still return `str` via
-  `str(p)` at every boundary (D-12 boundary preservation);
-  `HOME_DIR` stays a `str` constant; `Tmp.dir` / `Tmp.file` stay
-  `str` instance attributes. `pathlib.Path` aliased as `_Path`
-  module-level to avoid expanding the public surface
-  (audit-public-api stays exit 0). Lays foundation for
-  cement/core/* migrations.
-- `[core.config]` Migrate `cement/core/config.py` os.path.exists
-  callsite in `parse_file` to pathlib (Phase 03 D-11 scope
-  continuation). `import os` retained as a no-op (now `# noqa:
-  F401`) because `cement.core.config:os` is in
-  `03-PUBLIC-API-BASELINE.txt` — removing it would have shrunk
-  the public surface (D-12). Smallest of the four pathlib
-  commits (1 callsite); natural warm-up after fs.py per D-13.
-- `[core.foundation]` Migrate `cement/core/foundation.py`
-  os.path.isdir callsite in `_find_config_files` to pathlib
-  (Phase 03 D-11). The public alias `join = os.path.join` (line
-  48) retained per D-12/D-14 with `# boundary:` tag — it is part
-  of the public-API baseline (`cement.core.foundation:join`)
-  with stdlib semantics that downstream callers depend on.
-  D-19 protected `.format(**template_dict)` callsites at lines
-  1383, 1388, 1396, 1401, 1409, 1414, 1502, 1507, 1512, 1516,
-  1577, 1582, 1587, 1591 (14 total) untouched. A docstring
-  example referencing `os.path.dirname` / `os.path.exists` /
-  `os.makedirs` updated to pathlib idioms for consistency.
-- `[core.template]` Migrate `cement/core/template.py` os.path
-  internals to pathlib (Phase 03 D-11; ~13 callsites — biggest
-  single-file blast in the pathlib scope). Boundary-preservation
-  rule (D-12) held; internal locals are Path; values crossing
-  the loop iteration go back through `str()` because the
-  surrounding loop variables (`cur_dir_dest`, `sub_dir_dest`,
-  `_file`, `_file_dest`, `full_path`) are passed to legacy
-  string-typed APIs (`fs.abspath`, `self.render`, `open`). The
-  `os.walk(src)` callsite is retained with an inline `# boundary:`
-  comment per D-14 — pathlib has no direct equivalent yielding
-  the `(cur_dir, sub_dirs, files)` triple shape this loop
-  depends on; converting to `Path.rglob('*')` would require a
-  wholesale loop restructure with higher regression risk than
-  the boundary-tag accommodation. Closes the D-11 pathlib scope
-  across all 4 named files; D-24 conjunct #8 GREEN
-  (`grep -rn 'os\.path' cement/utils/fs.py cement/core/* | grep
-  -v '# boundary:' | wc -l` returns 0).
-- `[dev]` Audit `pragma:nocover` sites in `cement/core/` with
-  D-15 locked-vocabulary category labels (Phase 03 Wave 7
-  Batch A — 16 files / per-file atomic commits). Categories
-  applied: `abstract method`, `TYPE_CHECKING import`,
-  `platform-specific`, `defensive: unreachable`,
-  `untestable: signal handler`, `version constant`. Coverage
-  exclusion behavior unchanged; pragma comments now carry
-  audit-grep-friendly category labels per D-15.
-- `[dev]` Audit `pragma:nocover` sites in `cement/ext/` first
-  half (ext_alarm, ext_argparse, ext_colorlog, ext_configparser,
-  ext_daemon, ext_dummy, ext_generate, ext_jinja2, ext_json,
-  ext_logging) with D-15 locked-vocabulary category labels
-  (Phase 03 Wave 7 Batch B — 10 files / per-file atomic
-  commits). Categories applied: `TYPE_CHECKING import`,
-  `defensive: unreachable`, `untestable: dynamic import`,
-  `platform-specific`.
-- `[dev]` Audit `pragma:nocover` sites in `cement/ext/` second
-  half (ext_memcached, ext_mustache, ext_plugin, ext_print,
-  ext_redis, ext_scrub, ext_smtp, ext_tabulate, ext_watchdog,
-  ext_yaml) with D-15 locked-vocabulary category labels
-  (Phase 03 Wave 7 Batch C — 10 files / per-file atomic
-  commits). Categories applied: `TYPE_CHECKING import`,
-  `defensive: unreachable`, `untestable: dynamic import`.
-- `[dev]` Audit `pragma:nocover` sites in `cement/cli/` +
-  `cement/utils/` (cli/main.py, utils/fs.py, utils/shell.py,
-  utils/version.py) with D-15 locked-vocabulary category
-  labels (Phase 03 Wave 7 Batch D — 4 files / per-file
-  atomic commits). Closes COV-03 / D-24 conjunct #7 across
-  all of cement/: `grep -nE 'pragma:[[:space:]]*no[[:space:]]*cover' cement/ | grep -vE '# (<8 categories>)'`
-  returns empty (141 sites all carry locked-vocabulary
-  category labels).
-- `[core.deprecations]` Pin 3.0.10-1 and 3.0.16-1 removal version to v3.2.0
-- `[ext.logging]` Tighten FATAL deprecation removal version in docstrings
-- `[ext.smtp]` Document send() bool-return removal in v3.2.0
-- `[cli]` Migrate `cement generate todo-tutorial` template from
-  setup.py/setup.cfg/requirements*.txt/MANIFEST.in to pdm-backend with
-  full PEP 621 metadata and a PEP 735 dev group (mirrors the `generate
-  project` migration; #735)
-- `[cli]` Ship `[tool.ruff]` / `[tool.mypy]` / `[tool.pytest]` gate
-  config in the generated project and todo-tutorial `pyproject.toml` so
-  `make comply` and `make test` are green out of the box (#735)
-- `[cli]` Type-annotate all generated templates (project/script/
-  extension/plugin/todo) and modernize idioms to f-strings (#735)
+  `Optional[X]`→`X | None`); prune orphaned `typing.Optional` imports
+- `[core]` Move `Callable`/`Generator` imports from `typing` to
+  `collections.abc` (UP035)
+- `[core]` Convert printf-style format strings to modern format (UP031);
+  protected `.format(**template_dict)` template callsites preserved
+- `[core]` Drop redundant `(object)` base classes (UP004)
+- `[core]` Simplify `super()` calls to the zero-arg form (UP008)
+- `[core]` Drop the redundant `'r'` mode argument from `open()` calls
+  (UP015)
+- `[core]` Replace the `IOError` alias with `OSError` (UP024)
+- `[dev]` Drop the legacy `u"..."` unicode literal prefix in test code
+  (UP025)
+- `[dev]` Replace the deprecated `mock` import with `unittest.mock` (UP026)
+- `[core]` Replace `for x in iterable: yield x` with `yield from` (UP028)
+- `[core]` Convert `.format()` calls to f-strings (UP032); protected
+  template callsites preserved
+- `[core]` Tighten `Any` types in `cement/core/` where narrower types are
+  provably correct; surviving `Any` carries inline justification
+- `[dev]` Refresh CONVENTIONS.md type-annotation guidance to PEP 585 / PEP
+  604 syntax
+- `[core]` Wrap long log/error messages (E501) and reorder imports (I001)
+  surfaced by the UP sweeps
+- `[core]` Drop `from __future__ import annotations` from all 29 `cement/`
+  files (native on 3.10+); convert affected forward references to PEP 484
+  string annotations
+- `[utils.fs]` Migrate `cement/utils/fs.py` internals to pathlib while
+  preserving `str` return boundaries (public surface unchanged)
+- `[core.config]` Migrate the `config.py` `parse_file` os.path callsite to
+  pathlib; retain `import os` as a no-op to keep the public surface intact
+- `[core.foundation]` Migrate the `foundation.py` `_find_config_files`
+  os.path callsite to pathlib; retain the public `join = os.path.join`
+  alias and leave protected template callsites untouched
+- `[core.template]` Migrate `template.py` os.path internals to pathlib;
+  retain the `os.walk(src)` callsite (no direct pathlib equivalent for the
+  triple-tuple loop)
+- `[dev]` Audit `pragma: nocover` sites in `cement/core/` with
+  locked-vocabulary category labels
+- `[dev]` Audit `pragma: nocover` sites in `cement/ext/` (first half) with
+  locked-vocabulary category labels
+- `[dev]` Audit `pragma: nocover` sites in `cement/ext/` (second half) with
+  locked-vocabulary category labels
+- `[dev]` Audit `pragma: nocover` sites in `cement/cli/` and
+  `cement/utils/` with locked-vocabulary category labels
+- `[core.deprecations]` Pin the `3.0.10-1` and `3.0.16-1` deprecation
+  removal versions to v3.2.0
+- `[ext.logging]` Tighten the FATAL deprecation removal version in
+  docstrings
+- `[ext.smtp]` Document the `send()` bool-return removal in v3.2.0
+- `[cli]` Migrate the `cement generate todo-tutorial` template to
+  pdm-backend with full PEP 621 metadata and a PEP 735 dev group (mirrors
+  `generate project`; #735)
+- `[cli]` Ship `[tool.ruff]`/`[tool.mypy]`/`[tool.pytest]` gate config in
+  the generated project and todo-tutorial so `make comply`/`make test` are
+  green out of the box (#735)
+- `[cli]` Type-annotate all generated templates
+  (project/script/extension/plugin/todo) and modernize idioms to f-strings
+  (#735)
 
 Misc:
 
-- `[ci]` Add automated release workflow (`release.yml`) — tag-triggered
-  pipeline: preflight guard → full gate suite → isolated build → TestPyPI
-  publish + 5-Python install smoke → environment-gated OIDC PyPI publish
-  (single human approval) → post-approval fan-out (Docker Hub multi-arch
-  images, `stable/3.0.x` fast-forward, RTD docs-tag re-point, GitHub
-  Release from changelog, dev-version-bump PR, post-release checklist
-  issue); `workflow_dispatch` runs the same pipeline as a dry run
-- `[ci]` Refactor PR gate chain into reusable `gates.yml`
-  (`workflow_call`) shared by PR CI and the release workflow; wire the
-  test matrix Python versions (previously every leg ran the default
-  interpreter); new Windows core-test and macOS/Windows native CLI
-  smoke gates authored but disabled pending test portability work
-  (backlog 999.2)
-- `[dev]` Add release dev-tooling scripts: `testpypi-smoke.py`
-  (TestPyPI install round-trip), `cli-smoke-native.py` (cross-platform
-  CLI smoke), `bump_dev_version.py` (post-release dev-cycle bump)
+- `[ci]` Add GitHub Actions PR CI (`build_and_test.yml`) running the test
+  suite on pull requests with minimal permissions — #757
+- `[ci]` Add an automated release workflow (`release.yml`) — tag-triggered:
+  preflight guard → gate suite → isolated build → TestPyPI publish +
+  5-Python install smoke → environment-gated OIDC PyPI publish →
+  post-approval fan-out (Docker Hub multi-arch, `stable/3.0.x` sync, RTD
+  re-point, GitHub Release, dev-bump PR, checklist issue);
+  `workflow_dispatch` runs it as a dry run
+- `[ci]` Refactor the PR gate chain into a reusable `gates.yml`
+  (`workflow_call`) shared by PR CI and release; wire the matrix Python
+  versions; add (disabled) Windows core-test and macOS/Windows native smoke
+  gates
+- `[dev]` Add release dev-tooling scripts: `testpypi-smoke.py`,
+  `cli-smoke-native.py`, `bump_dev_version.py`
+- `[dev]` Add devbox/direnv development-environment configuration for
+  reproducible local setup
 - `[ext.smtp]` Isolate test defaults to prevent cross-test state pollution
-- `[dev]` Bump ruff to 0.15.x; codify rule sets explicitly; resolve all
-  surfacing lint findings (I001, B*, A*, C901, N*, PT*, T201, YTT203)
-- `[dev]` Bump mypy to ~=1.20.2; codify type-check surface (audit-point comment)
+- `[dev]` Bump ruff to 0.15.x; codify rule sets explicitly and resolve all
+  surfacing lint findings
+- `[dev]` Bump mypy to ~=1.20.2 and codify the type-check surface
 - `[dev]` Bump pytest 9.0.3, pytest-cov 7.1.0, coverage 7.13.5
-- `[dev]` Add `make cli-smoke-test` target — runs generated-project install
-  smoke test across Python 3.10–3.14 in Docker
-- `[dev]` Bump dev/extras lockfile to current non-breaking versions (redis
-  7.4, watchdog 6.0, tabulate 0.10, sphinx 8.1, requests 2.33, others)
-- `[dev]` Wire 100% coverage gate via `[tool.coverage.report]`
-  `fail_under` + `--cov-fail-under` addopts; explicit
-  `[tool.coverage.run] source/omit`
-- `[ci]` Pin GitHub Actions to exact tags (checkout v6.0.2,
-  setup-python v6.2.0, setup-pdm v4.4, install-package v1.1.0,
-  compose-action v2.6.0, update-deps-action v1.12)
-- `[ci]` Add PyPy 3.11 to CI test matrix (alongside existing PyPy 3.10)
-- `[ci]` Enable Dependabot for github-actions ecosystem (weekly)
-- `[ci]` Add workflow_dispatch trigger to pdm.yml
-- `[dev]` Add `make audit-public-api` target + AST-walk public surface enumerator + baseline snapshot (Phase 03 D-02..D-05).
-- `[dev]` Enable ruff `UP` (pyupgrade) and `FA` (flake8-future-annotations) families in extend-select with refreshed AUDIT POINT comment (Phase 03 D-06).
-- `[dev]` Capture Phase 03 Any-in-core baseline (D-09) + pragma + pathlib pre-counts in `03-VERIFICATION.md` (in-progress; finalized in Wave 8).
-- `[dev]` Phase 03 verification finalized: all 9 D-24 conjuncts GREEN;
-  REFACTOR-01..04 + COV-01..03 satisfied; record in
-  `03-VERIFICATION.md`.
-- `[dev]` Phase 03 (Internal Refactor & Coverage Hardening) complete:
-  REFACTOR-01..04 + COV-01..03 satisfied; ROADMAP updated.
-- `[docs]` Drop unsupported 'logo' theme option from sphinx conf
-- `[docs]` Remove orphan `docs/source/api/index.rst`; the top-level
-  `docs/source/index.rst` toctree references `api/core/index`,
-  `api/utils/index`, and `api/ext/index` directly
-- `[docs]` Rename `display_version` theme option to `version_selector`
-  (sphinx_rtd_theme 3.x rename)
-- `[docs]` Fix inline-literal RST in shell.cmd() docstring
-- `[docs]` Add top-level DEPRECATIONS.md mirroring GitBook narrative
-- `[dev]` Wire -W into make docs (zero-warnings gate)
-- `[docs]` Drop Travis CI link/badge (CI moved to GitHub Actions)
-- `[docs]` Align CONTRIBUTING with Conventional Commits +
-  atomic-per-concern
-- `[docs]` Expose `cement.core.deprecations` in the Sphinx API
-  reference (was missing) — adds `docs/source/api/core/deprecations.rst`
-  + toctree entry, plus minimal docstrings on the module,
-  `DEPRECATIONS` dict, and `deprecate()` so the autodoc page renders
-  meaningful content rather than an empty stub
-- `[docs]` Fix `stderror` → `stderr` typo in `cement.utils.shell:cmd()`
-  and `exec_cmd()` Returns docstrings (4 occurrences). Example
-  variables and runtime code already used the correct spelling
-- `[docs]` Remove orphaned `[Commit Guidelines]` reference-link
-  definition from `.github/CONTRIBUTING.md` (no body callsites
-  remained after the Plan 05-05 Conventional Commits rewrite)
-- `[dev]` Extend the CI `cli-smoke-test` to gate the generated
-  project's own `make comply` + `make test` and to build/install the
-  generated todo-tutorial (#735)
-- `[dev]` Add a generated-todo ruff-clean regression guard to cement's
-  test suite (`test_generate_todo_ruff_clean`) — generates
-  todo-tutorial and re-runs ruff against the rendered output (#735)
+- `[dev]` Add a `make cli-smoke-test` target — generated-project install
+  smoke across Python 3.10–3.14 in Docker
+- `[dev]` Bump the dev/extras lockfile to current non-breaking versions
+  (redis 7.4, watchdog 6.0, tabulate 0.10, sphinx 8.1, requests 2.33,
+  others)
+- `[dev]` Wire the 100% coverage gate via `[tool.coverage.report]`
+  `fail_under` + `--cov-fail-under`
+- `[ci]` Pin GitHub Actions to exact tags
+- `[ci]` Add PyPy 3.11 to the CI test matrix (alongside PyPy 3.10)
+- `[ci]` Enable Dependabot for the github-actions ecosystem (weekly)
+- `[ci]` Add a `workflow_dispatch` trigger to `pdm.yml`
+- `[dev]` Add a `make audit-public-api` target + AST-walk public-surface
+  enumerator + baseline snapshot
+- `[dev]` Enable ruff `UP` (pyupgrade) and `FA` (flake8-future-annotations)
+  families
+- `[dev]` Capture the Phase 03 Any-in-core / pragma / pathlib baselines in
+  `03-VERIFICATION.md`
+- `[dev]` Finalize Phase 03 verification (all D-24 conjuncts green;
+  REFACTOR-01..04 + COV-01..03 satisfied)
+- `[dev]` Complete Phase 03 (Internal Refactor & Coverage Hardening);
+  ROADMAP updated
+- `[docs]` Drop the unsupported `logo` theme option from the Sphinx config
+- `[docs]` Remove the orphan `docs/source/api/index.rst`
+- `[docs]` Rename `display_version` to `version_selector` (sphinx_rtd_theme
+  3.x)
+- `[docs]` Fix inline-literal RST in the `shell.cmd()` docstring
+- `[docs]` Add a top-level DEPRECATIONS.md mirroring the GitBook narrative
+- `[dev]` Wire `-W` into `make docs` (zero-warnings gate)
+- `[docs]` Drop the Travis CI link/badge (CI moved to GitHub Actions)
+- `[docs]` Align CONTRIBUTING with Conventional Commits + atomic-per-concern
+- `[docs]` Expose `cement.core.deprecations` in the Sphinx API reference
+  (was missing)
+- `[docs]` Fix a `stderror` → `stderr` typo in the `cement.utils.shell`
+  `cmd()`/`exec_cmd()` Returns docstrings
+- `[docs]` Remove an orphaned `[Commit Guidelines]` reference-link
+  definition from `.github/CONTRIBUTING.md`
+- `[dev]` Extend the CI `cli-smoke-test` to gate the generated project's own
+  `make comply`/`make test` and to build/install the generated todo-tutorial
+  (#735)
+- `[dev]` Add a generated-todo ruff-clean regression guard
+  (`test_generate_todo_ruff_clean`) (#735)
 
 Deprecations:
 
-- `[ext.smtp]` `SMTPMailHandler.send()` returning `bool` is deprecated; will return `senderrs` dict in a future version
+- `[ext.smtp]` `SMTPMailHandler.send()` returning `bool` is deprecated
+  (warn-only); it will return a `senderrs` dict, with removal targeted for
+  v3.2.0
 
 
 ## 3.0.14 - May 5, 2025

--- a/cement/core/backend.py
+++ b/cement/core/backend.py
@@ -1,3 +1,3 @@
 """Cement core backend module."""
 
-VERSION = (3, 0, 15, 'final', 0)  # pragma: nocover  # version constant
+VERSION = (3, 0, 16, 'final', 0)  # pragma: nocover  # version constant

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -6,6 +6,6 @@ def test_version():
     # ensure that we bump things properly on version changes
     assert backend.VERSION[0] == 3
     assert backend.VERSION[1] == 0
-    assert backend.VERSION[2] == 15
+    assert backend.VERSION[2] == 16
     assert backend.VERSION[3] == 'final'
     assert backend.VERSION[4] == 0


### PR DESCRIPTION
## Release prep: 3.0.16

This is the single release-prep PR for the 3.0.16 cut (Phase 06, Plan 02).
It finalizes the changelog and bumps the version of record. The merged
`main` commit is what will later be tagged.

### Changes

- **CHANGELOG.md** — finalize the `3.0.15 - DEVELOPMENT` section into a
  released `## 3.0.16 - July 13, 2026` section:
  - Renamed the header (no `DEVELOPMENT` marker).
  - Added a release-highlights paragraph covering the four locked themes:
    Python 3.10–3.14 matrix (3.8/3.9 dropped), warn-only deprecations with
    3.2.0 removals signposted, the automated GitHub Actions release
    workflow, and fully-typed modernized `cement generate` templates.
  - Condensed every entry to release-notes altitude while preserving all
    five buckets in order (Bugs, Features, Refactoring, Misc, Deprecations)
    and every entry (including `[dev]`).
- **cement/core/backend.py** — bump the single `VERSION` tuple to
  `(3, 0, 16, 'final', 0)` so `get_version()` returns `3.0.16`
  (pyproject.toml / `cement/__init__.py` derive the version dynamically).
- **tests/core/test_backend.py** — update the paired version assertion to
  `16`.

### D-01 git-log cross-check

Cross-checking `git log 3.0.14..HEAD` (after planning-artifact and
revert-pair filtering) against the populated buckets surfaced three
user-visible changes that were missing; they have been added:

- `[core]` explicit `__all__` for `from cement import *` (#756)
- `[ci]` base GitHub Actions PR CI, `build_and_test.yml` (#757)
- `[dev]` devbox/direnv development-environment configuration

### Gates (local, green)

- `make comply` — ruff + mypy clean
- `make test` — 386 passed, 100% coverage
- `make audit-public-api` — public surface byte-identical (exit 0)

### Notes for reviewer

- The DOCS-03 completeness check is a human judgment — please review the
  changelog 3.0.16 section (especially the highlights wording) for
  release-notes accuracy.
- This branch also carries the Phase 06 planning commits under
  `.planning/`. The only non-`.planning` changes are the four files above
  (`.gitignore` gained a `scratchpad/` ignore). Choose the merge method
  accordingly (e.g. squash, or filter `.planning/` if you prefer a
  code-only history on `main`).

Plan: `.planning/phases/06-release-cut-3-0-16/06-02-PLAN.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the application version to 3.0.16.
  * Published finalized release notes covering bug fixes, features, refactoring, and miscellaneous improvements.
  * Updated supported Python versions to 3.10–3.14.
  * Clarified that `SMTPMailHandler.send()` now issues warnings, with removal planned for v3.2.0.

* **Documentation**
  * Added detailed release planning, validation, provisioning, and verification guidance for the 3.0.16 release.

* **Tests**
  * Updated version checks to reflect 3.0.16.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->