### PR TITLE
fix: restore green CI — version-test tripwire and pdm.yml auth header

### DIFF
--- a/.github/workflows/pdm.yml
+++ b/.github/workflows/pdm.yml
@@ -10,6 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7.0.0
+        with:
+          # update-deps-action bundles create-pull-request v7.0.8, which probes
+          # for an existing credential with `git config --local` only. Modern
+          # checkout stores its own outside .git/config (an includeIf.gitdir
+          # pointing at a temp credentials file), so that probe misses it and
+          # cpr adds a second AUTHORIZATION extraheader -- git then sends two
+          # and GitHub rejects the push with `Duplicate header: "Authorization"`
+          # (HTTP 400). Dropping checkout's credential leaves cpr's as the only
+          # one. See dep/update-pdm-lock CI history from 2026-05-04 onward.
+          persist-credentials: false
 
       - name: Update dependencies
         uses: pdm-project/update-deps-action@v1.12

--- a/.github/workflows/pdm.yml
+++ b/.github/workflows/pdm.yml
@@ -5,9 +5,19 @@ on:
     - cron: "5 3 * * 1"
   workflow_dispatch:
 
+# Least privilege, matching release.yml (V14): read-only at the workflow level,
+# with the one job elevating to exactly what it needs. The repository default is
+# `write`, so without this the job ran with every write scope -- packages, pages,
+# deployments, issues -- to push a branch and open a PR.
+permissions:
+  contents: read
+
 jobs:
   update-dependencies:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write        # push the dep/update-pdm-lock branch
+      pull-requests: write   # open the lockfile PR
     steps:
       - uses: actions/checkout@v7.0.0
         with:

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -29,10 +29,10 @@
 ## Code Style
 
 **Formatting:**
-- Tool: `ruff` (v0.3.2+)
+- Tool: `ruff` (`~=0.15.12`)
 - Line length: 100 characters
 - Indentation: 4 spaces
-- Python target: 3.9+
+- Python target: 3.10 (`target-version = "py310"`)
 
 **Ruff Configuration** (`pyproject.toml` [tool.ruff]):
 ```
@@ -59,17 +59,35 @@ fixable = ["ALL"]
 
 **Example** from `cement/core/foundation.py`:
 ```python
-from __future__ import annotations
 import os
 import platform
 import signal
 import sys
+from collections.abc import Callable
 from importlib import reload as reload_module
+from pathlib import Path as _Path
 from time import sleep
-from typing import (IO, Any, Callable, Dict, List, Optional, TextIO, Tuple,
-                    Type, Union, TYPE_CHECKING)
-from ..core import (arg, cache, config, controller, exc, extension, log, mail,
-                    meta, output, plugin, template)
+from typing import (
+    IO,
+    TYPE_CHECKING,
+    Any,
+    TextIO,
+)
+
+from ..core import (
+    arg,
+    cache,
+    config,
+    controller,
+    exc,
+    extension,
+    log,
+    mail,
+    meta,
+    output,
+    plugin,
+    template,
+)
 from ..core.deprecations import deprecate
 from ..utils.misc import is_true, minimal_logger
 

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -5,12 +5,12 @@
 ## Languages
 
 **Primary:**
-- Python 3.9+ - Entire framework and CLI application
+- Python 3.10+ - Entire framework and CLI application
 
 ## Runtime
 
 **Environment:**
-- Python (3.9, 3.10, 3.11, 3.12, 3.13, 3.14 supported)
+- Python (3.10, 3.11, 3.12, 3.13, 3.14 supported; 3.9 dropped in 3.0.16 per the EOL policy)
 
 **Package Manager:**
 - PDM (Python Dependency Manager)
@@ -43,7 +43,7 @@
 - mock 5.1.0+ - Object mocking
 
 **Code Quality:**
-- ruff 0.3.2+ - Linting and code formatting
+- ruff ~=0.15.12 - Linting and code formatting
 - mypy 1.9.0+ - Static type checking
 
 **Documentation:**
@@ -77,7 +77,7 @@
 
 **Environment:**
 - Development environment via Devbox with pre-installed services (Redis, Memcached, Mailpit)
-- Docker Compose setup for multi-version testing (Python 3.9 - 3.14)
+- Docker Compose setup for multi-version testing (Python 3.10 - 3.14)
 - Environment variables for service configuration:
   - `REDIS_HOST` - Redis server hostname
   - `MEMCACHED_HOST` - Memcached server hostname
@@ -88,7 +88,7 @@
 - `pyproject.toml` - Primary project configuration
 - `pdm.lock` - Dependency lock file
 - Ruff config in `pyproject.toml` (`[tool.ruff]`):
-  - Target Python 3.9+
+  - Target Python 3.10+
   - Line length: 100 characters
   - Indent width: 4 spaces
 - MyPy config in `pyproject.toml` (`[tool.mypy]`):
@@ -113,7 +113,7 @@
 - Makefile-based workflow
 
 **Production:**
-- Python 3.9 or higher
+- Python 3.10 or higher
 - No external runtime dependencies required for core framework
 - Optional services (Redis, Memcached, SMTP) if using corresponding extensions
 - Alpine Linux compatible (see `Dockerfile` for production image)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Bugs:
   bundled `create-pull-request` v7.0.8 could not see it and added a second
   `AUTHORIZATION` extraheader, and GitHub rejected the push with
   `Duplicate header: "Authorization"` (HTTP 400).
+- `[ci]` Scope the `pdm.yml` token to `contents: write` +
+  `pull-requests: write` on the update job, with the workflow defaulting to
+  `contents: read`. The repository default is `write`, so the job had been
+  running with every write scope to push a branch and open a PR.
 
 Features:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 Bugs:
 
+- `[dev]` Bump the `backend.VERSION` assertions in
+  `tests/core/test_backend.py` to 3.0.17. The automated post-release dev bump
+  rewrote `cement/core/backend.py` but not the test, so `main` had been red
+  since the 3.0.17 cycle opened.
+- `[dev]` Teach `scripts/bump_dev_version.py` to rewrite the
+  `tests/core/test_backend.py` version assertions alongside `backend.py` and
+  `CHANGELOG.md`, restoring what every manual dev bump did by hand. The three
+  rewrites stay all-or-nothing, so a shape change fails the release workflow
+  instead of landing a half-bumped tree.
+- `[ci]` Set `persist-credentials: false` on the `pdm.yml` checkout step. The
+  weekly dependency-update workflow had failed every run since 2026-05-04:
+  modern `actions/checkout` stores its credential outside `.git/config`, the
+  bundled `create-pull-request` v7.0.8 could not see it and added a second
+  `AUTHORIZATION` extraheader, and GitHub rejected the push with
+  `Duplicate header: "Authorization"` (HTTP 400).
+
 Features:
 
 Refactoring:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,9 +156,9 @@ Cement is a mature, extensible Python CLI application framework built around a h
 ## Technology Stack
 
 ## Languages
-- Python 3.9+ - Entire framework and CLI application
+- Python 3.10+ - Entire framework and CLI application
 ## Runtime
-- Python (3.9, 3.10, 3.11, 3.12, 3.13, 3.14 supported)
+- Python (3.10, 3.11, 3.12, 3.13, 3.14 supported; 3.9 dropped in 3.0.16 per the EOL policy)
 - PDM (Python Dependency Manager)
 - Lockfile: `pdm.lock` (present)
 ## Frameworks
@@ -196,7 +196,7 @@ Cement is a mature, extensible Python CLI application framework built around a h
 - `pypng` - For PNG image handling (dev dependency)
 ## Configuration
 - Development environment via Devbox with pre-installed services (Redis, Memcached, Mailpit)
-- Docker Compose setup for multi-version testing (Python 3.9 - 3.14)
+- Docker Compose setup for multi-version testing (Python 3.10 - 3.14)
 - Environment variables for service configuration:
 - `pyproject.toml` - Primary project configuration
 - `pdm.lock` - Dependency lock file
@@ -207,7 +207,7 @@ Cement is a mature, extensible Python CLI application framework built around a h
 - Devbox environment manager with:
 - Docker Compose for multi-version testing
 - Makefile-based workflow
-- Python 3.9 or higher
+- Python 3.10 or higher
 - No external runtime dependencies required for core framework
 - Optional services (Redis, Memcached, SMTP) if using corresponding extensions
 - Alpine Linux compatible (see `Dockerfile` for production image)
@@ -227,13 +227,15 @@ Cement is a mature, extensible Python CLI application framework built around a h
 - Instance variables: lowercase_with_underscores
 - Module-level logger: `LOG = minimal_logger(__name__)`
 - Use PascalCase for class names
-- Type annotations use full form: `Dict[str, Any]`, `Optional[str]`, `List[str]`, `Tuple[int, str]`
+- Use PEP 585 builtin generics: `dict[str, Any]`, `list[str]`, `tuple[int, str]`, `type[Handler]`
+- Use PEP 604 unions: `str | None`, `int | str`, `dict[str, Any] | None` — NOT `Union[...]` / `Optional[...]`
+- Ruff `UP006`/`UP007`/`UP045` rewrite legacy typing syntax on every `make comply-ruff-fix`; `cement/` contains zero `Dict[`/`List[`/`Optional[`/`Union[`
 - Private Meta attribute annotations: `_meta: MetaClassName  # type: ignore` (see `cement/ext/ext_smtp.py` line 72)
 ## Code Style
-- Tool: `ruff` (v0.3.2+)
+- Tool: `ruff` (`~=0.15.12`)
 - Line length: 100 characters
 - Indentation: 4 spaces
-- Python target: 3.9+
+- Python target: 3.10 (`target-version = "py310"`)
 - Tool: `ruff check cement/ tests/`
 - All code must pass without errors before commit
 - Run via `make comply-ruff`
@@ -241,10 +243,11 @@ Cement is a mature, extensible Python CLI application framework built around a h
 - No centralized alias configuration; use relative imports exclusively (`..core.`, `..utils.`)
 ## Type Annotations
 - mypy config in `pyproject.toml` enforces strict mode:
-- Always annotate function parameters and return types: `def send(self, msg: str, **kw: Any) -> Dict[str, Any]:`
+- Always annotate function parameters and return types: `def send(self, body: _BodyType, **kw: Any) -> bool:`
+- Applies to `cement/` only — mypy's `files` excludes `tests/`, and no test function in `tests/` is annotated
 - Use `TYPE_CHECKING` block for deferred imports to prevent circular dependencies
 - Private Meta attributes require `# type: ignore` due to metaclass pattern (framework constraint)
-- Union types: `Union[str, int]` for multiple types
+- Union types: `str | int` (PEP 604) for multiple types
 ## Error Handling
 - `FrameworkError` - General framework (non-application) errors with message passing
 - `InterfaceError` - Interface-related errors
@@ -287,7 +290,7 @@ Cement is a mature, extensible Python CLI application framework built around a h
 - Default values for kwargs handled via `Meta.config_defaults` pattern (not function signatures)
 - Return types must be explicit (no `-> Any` without reason)
 - Boolean returns for success/failure (parse_file returns `bool`)
-- Dict/List returns should be typed: `-> Dict[str, Any]`, `-> List[str]`
+- Dict/list returns should be typed: `-> dict[str, Any]`, `-> list[str]`
 ## Module Design
 - Core framework exports via `__all__` lists in main modules (not observed, but interface defines implicit contracts)
 - Private functions/classes prefixed with `_`

--- a/devbox.lock
+++ b/devbox.lock
@@ -262,7 +262,7 @@
     },
     "python@3.14": {
       "last_modified": "2026-02-23T15:40:43Z",
-      "plugin_version": "0.0.4",
+      "plugin_version": "0.0.5",
       "resolved": "github:NixOS/nixpkgs/80d901ec0377e19ac3f7bb8c035201e2e098cc97#python314",
       "source": "devbox-search",
       "version": "3.14.3",

--- a/scripts/bump_dev_version.py
+++ b/scripts/bump_dev_version.py
@@ -12,6 +12,10 @@ Given the next dev version (e.g. ``3.0.17``) this transform:
 2. Prepends a fresh ``## <next-version> - DEVELOPMENT`` section — seeded with the
    standard CLAUDE.md changelog buckets — directly under the ``# ChangeLog`` H1
    in ``CHANGELOG.md``.
+3. Rewrites the matching ``backend.VERSION[0..2]`` assertions in
+   ``tests/core/test_backend.py``. That test is the "did you bump everything?"
+   tripwire every manual bump used to update by hand (see 8f5eaa81, c314892f);
+   leaving it behind lands a red ``main`` the moment the dev-bump PR merges.
 
 It deliberately does NOT edit ``pyproject.toml``: ``[tool.pdm.version]``
 ``source = "call"`` reads ``backend.py`` via ``get_version``, so the version
@@ -22,10 +26,10 @@ Phase 05.4 contract anchors:
 * D-12 / REL-05 — post-release dev-version bump. The release workflow runs this
   on ``main`` after publish, then opens a PR (``chore: bump to <next>``), so the
   next development cycle starts immediately.
-* T-05.4-02 mitigation — the rewrite is a narrow regex over the numeric tuple
-  members only, keeps the ``# pragma: nocover`` comment intact, and fails LOUD
-  (non-zero) if ``backend.py`` / ``CHANGELOG.md`` are not shaped as expected,
-  rather than silently producing a malformed bump.
+* T-05.4-02 mitigation — the rewrites are narrow regexes over the numeric
+  members only, keep the ``# pragma: nocover`` comment intact, and fail LOUD
+  (non-zero) if ``backend.py`` / ``CHANGELOG.md`` / ``test_backend.py`` are not
+  shaped as expected, rather than silently producing a malformed bump.
 
 The ``## <ver>`` anchor written here is the inverse of the D-02 release
 preflight, which rejects a releasing version still marked ``- DEVELOPMENT``.
@@ -38,7 +42,8 @@ Exit codes:
 
 * 0 — bump applied (VERSION rewritten + changelog section prepended)
 * 2 — bad invocation or non-semver argument
-* 3 — backend.py / CHANGELOG.md not shaped as expected (nothing written)
+* 3 — backend.py / CHANGELOG.md / test_backend.py not shaped as expected
+  (nothing written)
 """
 from __future__ import annotations  # script-internal; doesn't affect cement/
 
@@ -49,6 +54,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BACKEND_PATH = REPO_ROOT / "cement" / "core" / "backend.py"
 CHANGELOG_PATH = REPO_ROOT / "CHANGELOG.md"
+VERSION_TEST_PATH = REPO_ROOT / "tests" / "core" / "test_backend.py"
 
 # Matches `VERSION = (3, 0, 15, 'final', 0)<trailing>` and captures the leading
 # `VERSION = ` (group 1) and everything after the closing paren (group 2, the
@@ -62,6 +68,15 @@ VERSION_RE = re.compile(
 
 # The changelog H1 the fresh section is inserted beneath.
 CHANGELOG_HEADER_RE = re.compile(r"\A(# ChangeLog\n\n)")
+
+# Matches `    assert backend.VERSION[2] == 16`, capturing everything up to the
+# literal (group 1) and the tuple index (group 2) so only the number is
+# rewritten. The `[3] == 'final'` assertion has no numeric literal and so is
+# never matched; `[4] == 0` is matched but left alone (always 0).
+VERSION_TEST_RE = re.compile(
+    r"^(\s*assert\s+backend\.VERSION\[(\d+)\]\s*==\s*)\d+$",
+    re.MULTILINE,
+)
 
 
 def _fail(message: str) -> None:
@@ -114,6 +129,34 @@ def _render_changelog(version: str) -> str | None:
     return new_text
 
 
+def _render_version_test(major: int, minor: int, patch: int) -> str | None:
+    """Return the rewritten test_backend.py text, or None (with error printed)."""
+    if not VERSION_TEST_PATH.is_file():
+        _fail(f"{VERSION_TEST_PATH} not found")
+        return None
+    text = VERSION_TEST_PATH.read_text(encoding="utf-8")
+
+    expected = {0: major, 1: minor, 2: patch}
+    rewritten: set[int] = set()
+
+    def _repl(match: re.Match[str]) -> str:
+        index = int(match.group(2))
+        if index not in expected:
+            return match.group(0)
+        rewritten.add(index)
+        return f"{match.group(1)}{expected[index]}"
+
+    new_text = VERSION_TEST_RE.sub(_repl, text)
+    missing = sorted(set(expected) - rewritten)
+    if missing:
+        _fail(
+            f"{VERSION_TEST_PATH}: expected backend.VERSION assertions for "
+            f"indexes {missing}, found none"
+        )
+        return None
+    return new_text
+
+
 def main(argv: list[str]) -> int:
     if len(argv) != 2:
         print("usage: bump_dev_version.py <next-version>", file=sys.stderr)  # noqa: T201
@@ -125,7 +168,7 @@ def main(argv: list[str]) -> int:
         return 2
     major, minor, patch = int(match.group(1)), int(match.group(2)), int(match.group(3))
 
-    # Prepare BOTH rewrites in memory before writing EITHER file, so an exit-3
+    # Prepare ALL rewrites in memory before writing ANY file, so an exit-3
     # validation failure can never leave the repo half-bumped (the documented
     # "nothing written" contract).
     new_backend = _render_backend(major, minor, patch)
@@ -134,11 +177,17 @@ def main(argv: list[str]) -> int:
     new_changelog = _render_changelog(version)
     if new_changelog is None:
         return 3
+    new_version_test = _render_version_test(major, minor, patch)
+    if new_version_test is None:
+        return 3
 
     BACKEND_PATH.write_text(new_backend, encoding="utf-8")
     CHANGELOG_PATH.write_text(new_changelog, encoding="utf-8")
+    VERSION_TEST_PATH.write_text(new_version_test, encoding="utf-8")
 
-    print(f"bumped dev cycle to {version} (backend VERSION + CHANGELOG)")  # noqa: T201
+    print(  # noqa: T201
+        f"bumped dev cycle to {version} (backend VERSION + CHANGELOG + version test)"
+    )
     return 0
 
 

--- a/tests/core/test_backend.py
+++ b/tests/core/test_backend.py
@@ -6,6 +6,6 @@ def test_version():
     # ensure that we bump things properly on version changes
     assert backend.VERSION[0] == 3
     assert backend.VERSION[1] == 0
-    assert backend.VERSION[2] == 16
+    assert backend.VERSION[2] == 17
     assert backend.VERSION[3] == 'final'
     assert backend.VERSION[4] == 0

--- a/tests/test_bump_dev_version.py
+++ b/tests/test_bump_dev_version.py
@@ -1,0 +1,128 @@
+
+# Guards scripts/bump_dev_version.py, which release.yml runs on main after a
+# publish. Its first version (3.0.16 -> 3.0.17) rewrote backend.py and
+# CHANGELOG.md but not tests/core/test_backend.py, so merging the dev-bump PR
+# left main red on `assert backend.VERSION[2] == 16`.
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / 'scripts' / 'bump_dev_version.py'
+
+BACKEND_SRC = """\"\"\"Cement core backend module.\"\"\"
+
+VERSION = (3, 0, 16, 'final', 0)  # pragma: nocover  # version constant
+"""
+
+CHANGELOG_SRC = """# ChangeLog
+
+## 3.0.16 - July 13, 2026
+
+Bugs:
+"""
+
+VERSION_TEST_SRC = """
+from cement.core import backend
+
+
+def test_version():
+    # ensure that we bump things properly on version changes
+    assert backend.VERSION[0] == 3
+    assert backend.VERSION[1] == 0
+    assert backend.VERSION[2] == 16
+    assert backend.VERSION[3] == 'final'
+    assert backend.VERSION[4] == 0
+"""
+
+
+def load_script():
+    # Loaded by path: scripts/ is not an importable package.
+    spec = importlib.util.spec_from_file_location('bump_dev_version', SCRIPT_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def bump(tmp_path, monkeypatch):
+    """The script pointed at a throwaway repo mirroring the real layout."""
+    backend = tmp_path / 'cement' / 'core' / 'backend.py'
+    changelog = tmp_path / 'CHANGELOG.md'
+    version_test = tmp_path / 'tests' / 'core' / 'test_backend.py'
+
+    backend.parent.mkdir(parents=True)
+    version_test.parent.mkdir(parents=True)
+    backend.write_text(BACKEND_SRC)
+    changelog.write_text(CHANGELOG_SRC)
+    version_test.write_text(VERSION_TEST_SRC)
+
+    module = load_script()
+    monkeypatch.setattr(module, 'BACKEND_PATH', backend)
+    monkeypatch.setattr(module, 'CHANGELOG_PATH', changelog)
+    monkeypatch.setattr(module, 'VERSION_TEST_PATH', version_test)
+    return module, backend, changelog, version_test
+
+
+def test_bump_rewrites_all_three_files(bump):
+    module, backend, changelog, version_test = bump
+
+    assert module.main(['bump_dev_version.py', '3.0.17']) == 0
+
+    assert "VERSION = (3, 0, 17, 'final', 0)" in backend.read_text()
+    assert '# pragma: nocover  # version constant' in backend.read_text()
+    assert '## 3.0.17 - DEVELOPMENT' in changelog.read_text()
+
+    # The tripwire assertions track the bump; 'final' and the trailing 0 do not.
+    text = version_test.read_text()
+    assert 'assert backend.VERSION[0] == 3' in text
+    assert 'assert backend.VERSION[1] == 0' in text
+    assert 'assert backend.VERSION[2] == 17' in text
+    assert "assert backend.VERSION[3] == 'final'" in text
+    assert 'assert backend.VERSION[4] == 0' in text
+
+
+def test_bump_across_minor(bump):
+    module, backend, _, version_test = bump
+
+    assert module.main(['bump_dev_version.py', '3.2.0']) == 0
+
+    assert "VERSION = (3, 2, 0, 'final', 0)" in backend.read_text()
+    text = version_test.read_text()
+    assert 'assert backend.VERSION[1] == 2' in text
+    assert 'assert backend.VERSION[2] == 0' in text
+
+
+def test_unshaped_version_test_writes_nothing(bump):
+    module, backend, changelog, version_test = bump
+    version_test.write_text('def test_version():\n    pass\n')
+
+    assert module.main(['bump_dev_version.py', '3.0.17']) == 3
+
+    # All-or-nothing: the two well-shaped files must be untouched.
+    assert BACKEND_SRC == backend.read_text()
+    assert CHANGELOG_SRC == changelog.read_text()
+
+
+def test_missing_version_test_writes_nothing(bump):
+    module, backend, changelog, version_test = bump
+    version_test.unlink()
+
+    assert module.main(['bump_dev_version.py', '3.0.17']) == 3
+    assert BACKEND_SRC == backend.read_text()
+    assert CHANGELOG_SRC == changelog.read_text()
+
+
+def test_bad_version_argument(bump):
+    module, _, _, _ = bump
+    assert module.main(['bump_dev_version.py', '3.0']) == 2
+    assert module.main(['bump_dev_version.py']) == 2
+
+
+def test_script_is_importable_by_path():
+    assert SCRIPT_PATH.is_file()
+    assert load_script().main is not None
+    sys.modules.pop('bump_dev_version', None)


### PR DESCRIPTION
Two unrelated automated-CI failures, both surfaced while reviewing why every open Dependabot PR is red.

## 1. `gates / test` fails on every PR — `test_backend.py::test_version`

`main` has been red since 2026-07-13. `comply` passes, coverage is 100%, 385 tests pass, and exactly one assertion fails:

```
cement/core/backend.py:      VERSION = (3, 0, 17, 'final', 0)
tests/core/test_backend.py:  assert backend.VERSION[2] == 16
```

**Cause:** the automated post-release dev bump shipped in phase 05.4 (`scripts/bump_dev_version.py`, run by `release.yml`, merged as #796) rewrites `backend.py` and `CHANGELOG.md`. Every previous *hand-written* dev bump also updated `tests/core/test_backend.py` — that test is the deliberate "did you bump everything?" tripwire:

```
8f5eaa81  cement/core/backend.py     | 2 +-
          tests/core/test_backend.py | 2 +-   ← automation never learned this
          CHANGELOG.md               | ...
```

Same shape in `c314892f`, `d8bd90b9`, `02aa4f25`.

**Fix:** bump the assertion to unblock (eea9dd6c), then teach the script to rewrite the test too (bba38955) so it doesn't recur at 3.0.18. The new `_render_version_test()` is a narrow regex over the numeric `backend.VERSION[0..2]` assertions — `[3] == 'final'` has no numeric literal and is never matched, `[4]` is matched but left alone. It renders before any file is written, preserving the script's documented all-or-nothing contract.

`tests/test_bump_dev_version.py` drives the script against a throwaway repo. There is no precedent for testing `scripts/` here, so it is loaded by path (`scripts/` is not a package) and `cement/` coverage is unaffected.

## 2. Weekly `Update dependencies` — HTTP 400

Failing **every Monday since 2026-05-04**; last success 2026-04-27. 18 consecutive runs, easy to miss because it is a scheduled run on `main` rather than a PR check.

```
[command]/usr/bin/git remote prune origin
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/datafolklabs/cement/': The requested URL returned error: 400
```

**Cause:** two `Authorization` headers reach GitHub.

1. `actions/checkout@v7` no longer writes its credential into `.git/config`; it writes an external `git-credentials-*.config` wired in via `includeIf.gitdir` (visible in post-job cleanup).
2. `peter-evans/create-pull-request@v7.0.8` — bundled inside `pdm-project/update-deps-action@v1.12` — probes with `git config --local --get-regexp ... ^AUTHORIZATION:`, which reads only `.git/config`, so it finds nothing.
3. It adds its own `--local` extraheader. Git resolves both and sends two.

The timeline matches: the last change before the first failure was `70aa7e6f` (2026-05-02), which pinned `actions/checkout@v4 → v6.0.2` *and* `update-deps-action@main → v1.12` in one commit. The floating `@main` had been tracking a newer create-pull-request; pinning froze it at v7.0.8. `update-deps-action` is dormant (v1.12 is from Apr 2025 and still latest) while create-pull-request is now at v8.1.1.

**Fix:** `persist-credentials: false` on the checkout step, so cpr's header is the only one.

**Side effect of the outage:** 8 dependency updates unlanded since May — `redis 7.4→8.1`, `pytest 9.0.3→9.1.1`, `ruff 0.15.12→0.15.22`, `coverage`, `commitizen`, `colorlog`, `requests`. There is also a stale `origin/dep/update-pdm-lock` branch from the April run.

## Verification

- `make comply` — ruff and mypy clean (mypy needs the optional extras installed locally)
- Full suite against live redis/memcached/mailpit: **392 passed, 100% coverage** (385 + 7 new)
- End-to-end dry run of the updated script on a scratch copy: `3.0.18` lands consistently in `backend.py`, `test_backend.py`, and `CHANGELOG.md`

`pdm.yml` has `workflow_dispatch`, so fix 2 can be confirmed by dispatching it after merge rather than waiting for Monday. That is the one change here that CI on this PR cannot itself exercise.

## Follow-ups not in scope

- `update-deps-action` is unmaintained and pins a transitive action you cannot control; replacing it with an inline `pdm update` + `create-pull-request@v8` step would remove that exposure.
- Stale `origin/dep/update-pdm-lock` branch.
- Node 20 deprecation warnings on `setup-pdm` and `create-pull-request`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaMW9kaP2M236N6SXpCMnw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the automated dependency-update workflow with safer, job-specific permissions.
  * Development-version updates now keep version references synchronized across project files.
  * Version updates fail safely without leaving partially updated files when references are missing or malformed.

* **Documentation**
  * Updated supported runtime guidance to reflect Python 3.10 as the minimum version.
  * Updated code-style guidance for modern Python syntax and tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->