### PR TITLE
fix(ext.logging): clear handlers deterministically across CPython patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Bugs:
   `pull-requests: write` on the update job, with the workflow defaulting to
   `contents: read`. The repository default is `write`, so the job had been
   running with every write scope to push a branch and open a PR.
+- `[ext.logging]` Fix `clear_loggers()` leaving handlers behind. The three
+  handler-removal loops iterated `Logger.handlers` while `removeHandler()`
+  mutated it, so every other handler was skipped -- the cause of the two
+  long-standing `FIXME: self._clear_loggers() should be preventing this but
+  it's not!` comments. CPython 3.13.15 and 3.14.7 changed `removeHandler()` to
+  rebind `Logger.handlers` rather than mutate it in place, which silently made
+  the same call clear *everything* on those patch versions and left a
+  handler-less logger. The loops now iterate a copy and `clear_loggers()`
+  explicitly leaves a `NullHandler` attached, so behavior is identical on every
+  supported interpreter and matches what callers have always observed.
 
 Features:
 

--- a/cement/ext/ext_logging.py
+++ b/cement/ext/ext_logging.py
@@ -178,10 +178,24 @@ class LoggingLogHandler(log.LogHandler):
     def clear_loggers(self, namespace: str) -> None:
         """Clear any previously configured loggers for ``namespace``."""
 
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
-            logging.getLogger(f"cement:app:{namespace}").removeHandler(i)
+        logger = logging.getLogger(f"cement:app:{namespace}")
 
-        self.backend = logging.getLogger(f"cement:app:{namespace}")
+        # Iterate over a copy. `removeHandler()` mutates `Logger.handlers` in
+        # place on CPython up to 3.13.14 / 3.14.6, but rebinds it to a new list
+        # from 3.13.15 / 3.14.7 onward. Iterating the attribute live therefore
+        # skipped every other handler on the former and cleared everything on
+        # the latter -- the same call did different things depending on the
+        # interpreter's patch version. A copy makes every version agree.
+        for i in list(logger.handlers):
+            logger.removeHandler(i)
+
+        # Leave a NullHandler attached. Older CPython left one behind as a
+        # side effect of the skipping above, so this is the state callers have
+        # always observed; making it explicit keeps that contract on the newer
+        # patch versions instead of handing back a handler-less logger.
+        logger.addHandler(NullHandler())
+
+        self.backend = logger
 
     def _get_console_format(self) -> str:
         if self.get_level() == logging.getLevelName(logging.DEBUG):
@@ -220,10 +234,13 @@ class LoggingLogHandler(log.LogHandler):
         else:
             console_handler = NullHandler()
 
-        # FIXME: self._clear_loggers() should be preventing this but it's not!
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
-            if isinstance(i, logging.StreamHandler):
-                self.backend.removeHandler(i)
+        # Iterate over a copy -- see clear_loggers() for why. This loop is what
+        # the old `FIXME: self._clear_loggers() should be preventing this but
+        # it's not!` comment was working around: clear_loggers() was in fact
+        # leaving handlers behind, because it had this same bug.
+        for i in list(logging.getLogger(f"cement:app:{namespace}").handlers):
+            if isinstance(i, logging.StreamHandler):    # pragma: nocover  # defensive: unreachable
+                self.backend.removeHandler(i)           # pragma: nocover  # defensive: unreachable
 
         self.backend.addHandler(console_handler)
 
@@ -261,8 +278,8 @@ class LoggingLogHandler(log.LogHandler):
         else:
             file_handler = NullHandler()
 
-        # FIXME: self._clear_loggers() should be preventing this but it's not!
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
+        # Iterate over a copy -- see clear_loggers() for why.
+        for i in list(logging.getLogger(f"cement:app:{namespace}").handlers):
             if isinstance(i, file_handler.__class__):   # pragma: nocover  # defensive: unreachable
                 self.backend.removeHandler(i)           # pragma: nocover  # defensive: unreachable
 

--- a/tests/ext/test_ext_logging.py
+++ b/tests/ext/test_ext_logging.py
@@ -82,9 +82,13 @@ def test_clear_loggers():
 def test_clear_loggers_via_keyword():
     with TestApp() as app:
         label = app._meta.label
-        han = logging.getLogger(f"cement:app:{label}").handlers
         MyLog = LoggingLogHandler(clear_loggers=[f"{label}:{label}"])
         MyLog._setup(app)
+        # Read the handlers after _setup, not before. removeHandler() rebinds
+        # Logger.handlers to a new list on CPython 3.13.15 / 3.14.7+, so a
+        # reference captured up front goes stale instead of tracking the
+        # logger, and this asserted against the pre-setup state.
+        han = logging.getLogger(f"cement:app:{label}").handlers
         assert len(han) == 1
         assert isinstance(han[0], logging.NullHandler)
 


### PR DESCRIPTION
A pre-existing bug in `cement/ext/ext_logging.py`, surfaced by an upstream CPython change. Found while diagnosing why `gates / test` was red on #805; it is unrelated to that PR and needed its own fix.

## What upstream changed

CPython changed `logging.Logger.removeHandler` to **rebind `self.handlers` to a new list** instead of mutating it in place. Pure-stdlib probe, no cement involved:

| Python | `lg.handlers is before` after `removeHandler` |
| --- | --- |
| 3.10.21, 3.11.16, 3.12.14 | `True` — mutates in place |
| **3.13.15, 3.14.7** | **`False` — rebinds** |

## Why that broke cement

Three loops had the shape:

```python
for i in logging.getLogger(f"cement:app:{namespace}").handlers:
    logging.getLogger(f"cement:app:{namespace}").removeHandler(i)
```

That is mutation during iteration. On older CPython the list shrinks under the iterator, so it **skips every other handler** and some survive. Two of the three loops carried this comment:

```python
# FIXME: self._clear_loggers() should be preventing this but it's not!
```

`clear_loggers()` was indeed not clearing — because it had the same bug as the workarounds written to compensate for it. The symptom was noticed long ago; the cause was not.

On 3.13.15+/3.14.7+ the iterator sees a stable snapshot and removes everything, so **cement's public `clear_loggers()` started behaving differently depending on the interpreter's patch version**, handing back a handler-less logger where it previously left one attached. `tests/ext/test_ext_logging.py:77` encoded the old accident as intent (`# Nullhandler remains`).

## The fix

- Iterate a **copy** in all three loops — the actual bug.
- `clear_loggers()` explicitly attaches a `NullHandler`. Older CPython left one behind as a side effect of the skipping, so this **preserves the state callers have always observed** rather than adopting the new accidental behavior. No BC break on the 3.0.x track.
- The console workaround loop is now genuinely unreachable, so it gets the same `# pragma: nocover  # defensive: unreachable` its file-log twin already carries.
- `test_clear_loggers_via_keyword` captured `.handlers` *before* `_setup` and asserted on it afterwards — only valid while the list was mutated in place. It now reads the list after `_setup`, preserving the assertion's intent.

## Verification

Handler state is now **identical on both sides of the CPython split**:

```
3.14.6  after app setup: [StreamHandler, NullHandler]   after MyLog._setup: [NullHandler]
3.14.7  after app setup: [StreamHandler, NullHandler]   after MyLog._setup: [NullHandler]
```

`tests/ext/test_ext_logging.py` + `test_ext_colorlog.py`, same code, four interpreters:

| Python | Before | After |
| --- | --- | --- |
| 3.12.14 | 10 passed | 10 passed |
| 3.14.6 | 10 passed | 10 passed |
| 3.13.15 | **2 failed** | 10 passed |
| 3.14.7 | **2 failed** | 10 passed |

Also locally: `make comply` clean (ruff + mypy), full suite 100% coverage, and `make audit-public-api` reports zero drift against the frozen baseline.

## Notes

- **`gates / test` will still fail here** on `test_backend.py::test_version` — that is the separate `main` breakage fixed by #805. This branch is cut from `main`, so it carries it. Merge #805 first and this goes green.
- **Small CHANGELOG conflict with #805** is expected; both append to the 3.0.17 `Bugs:` bucket.
- This reached CI because `gates.yml` sets `python-version: "3.x"` on the `test` job, which floated 3.14.6 → 3.14.7. Left as-is per maintainer preference — the early warning is the point — but worth knowing that upstream patch releases can turn the primary gate red with no repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaMW9kaP2M236N6SXpCMnw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logger cleanup so handlers are removed consistently across supported Python versions.
  * Ensured cleared loggers retain a safe default handler.
  * Improved console and file logging setup when replacing existing handlers.

* **Documentation**
  * Added a changelog entry documenting the logging cleanup fix for the upcoming 3.0.17 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->