### PR TITLE
fix(ext.logging): clear handlers deterministically across CPython patch versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ Bugs:
   `pull-requests: write` on the update job, with the workflow defaulting to
   `contents: read`. The repository default is `write`, so the job had been
   running with every write scope to push a branch and open a PR.
+- `[ext.logging]` Fix `clear_loggers()` leaving handlers behind. The three
+  handler-removal loops iterated `Logger.handlers` while `removeHandler()`
+  mutated it, so every other handler was skipped -- the cause of the two
+  long-standing `FIXME: self._clear_loggers() should be preventing this but
+  it's not!` comments. CPython 3.13.15 and 3.14.7 changed `removeHandler()` to
+  rebind `Logger.handlers` rather than mutate it in place, which silently made
+  the same call clear *everything* on those patch versions and left a
+  handler-less logger. The loops now iterate a copy and `clear_loggers()`
+  explicitly leaves a `NullHandler` attached, so behavior is identical on every
+  supported interpreter and matches what callers have always observed.
 
 Features:
 

--- a/cement/ext/ext_logging.py
+++ b/cement/ext/ext_logging.py
@@ -178,10 +178,24 @@ class LoggingLogHandler(log.LogHandler):
     def clear_loggers(self, namespace: str) -> None:
         """Clear any previously configured loggers for ``namespace``."""
 
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
-            logging.getLogger(f"cement:app:{namespace}").removeHandler(i)
+        logger = logging.getLogger(f"cement:app:{namespace}")
 
-        self.backend = logging.getLogger(f"cement:app:{namespace}")
+        # Iterate over a copy. `removeHandler()` mutates `Logger.handlers` in
+        # place on CPython up to 3.13.14 / 3.14.6, but rebinds it to a new list
+        # from 3.13.15 / 3.14.7 onward. Iterating the attribute live therefore
+        # skipped every other handler on the former and cleared everything on
+        # the latter -- the same call did different things depending on the
+        # interpreter's patch version. A copy makes every version agree.
+        for i in list(logger.handlers):
+            logger.removeHandler(i)
+
+        # Leave a NullHandler attached. Older CPython left one behind as a
+        # side effect of the skipping above, so this is the state callers have
+        # always observed; making it explicit keeps that contract on the newer
+        # patch versions instead of handing back a handler-less logger.
+        logger.addHandler(NullHandler())
+
+        self.backend = logger
 
     def _get_console_format(self) -> str:
         if self.get_level() == logging.getLevelName(logging.DEBUG):
@@ -220,10 +234,13 @@ class LoggingLogHandler(log.LogHandler):
         else:
             console_handler = NullHandler()
 
-        # FIXME: self._clear_loggers() should be preventing this but it's not!
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
-            if isinstance(i, logging.StreamHandler):
-                self.backend.removeHandler(i)
+        # Iterate over a copy -- see clear_loggers() for why. This loop is what
+        # the old `FIXME: self._clear_loggers() should be preventing this but
+        # it's not!` comment was working around: clear_loggers() was in fact
+        # leaving handlers behind, because it had this same bug.
+        for i in list(logging.getLogger(f"cement:app:{namespace}").handlers):
+            if isinstance(i, logging.StreamHandler):    # pragma: nocover  # defensive: unreachable
+                self.backend.removeHandler(i)           # pragma: nocover  # defensive: unreachable
 
         self.backend.addHandler(console_handler)
 
@@ -261,8 +278,8 @@ class LoggingLogHandler(log.LogHandler):
         else:
             file_handler = NullHandler()
 
-        # FIXME: self._clear_loggers() should be preventing this but it's not!
-        for i in logging.getLogger(f"cement:app:{namespace}").handlers:
+        # Iterate over a copy -- see clear_loggers() for why.
+        for i in list(logging.getLogger(f"cement:app:{namespace}").handlers):
             if isinstance(i, file_handler.__class__):   # pragma: nocover  # defensive: unreachable
                 self.backend.removeHandler(i)           # pragma: nocover  # defensive: unreachable
 

--- a/tests/ext/test_ext_logging.py
+++ b/tests/ext/test_ext_logging.py
@@ -82,9 +82,13 @@ def test_clear_loggers():
 def test_clear_loggers_via_keyword():
     with TestApp() as app:
         label = app._meta.label
-        han = logging.getLogger(f"cement:app:{label}").handlers
         MyLog = LoggingLogHandler(clear_loggers=[f"{label}:{label}"])
         MyLog._setup(app)
+        # Read the handlers after _setup, not before. removeHandler() rebinds
+        # Logger.handlers to a new list on CPython 3.13.15 / 3.14.7+, so a
+        # reference captured up front goes stale instead of tracking the
+        # logger, and this asserted against the pre-setup state.
+        han = logging.getLogger(f"cement:app:{label}").handlers
         assert len(han) == 1
         assert isinstance(han[0], logging.NullHandler)
 


### PR DESCRIPTION
**Re-lands #806, which never reached `main`.**

#805 was rebase-merged, so `main` got new SHAs and `fix/ci-green` was orphaned. #806 then merged into that orphaned branch instead of into `main`. Net effect: `main` still carries the original buggy code — both `FIXME: self._clear_loggers() should be preventing this but it's not!` comments are still there.

This branch is cut fresh from `main` with #806's two commits cherry-picked. The diff is exactly #806 and nothing else:

```
CHANGELOG.md                  | 10 ++++++++++
cement/ext/ext_logging.py     | 35 ++++++++++++++++++++++++++---------
tests/ext/test_ext_logging.py |  6 +++++-
```

No content from #805 is duplicated — that is already on `main` under its rebased SHAs.

## What this fixes (unchanged from #806)

CPython changed `logging.Logger.removeHandler` to rebind `self.handlers` to a new list instead of mutating it in place, in **3.13.15 and 3.14.7** but not in 3.10/3.11/3.12.

cement had three loops iterating `Logger.handlers` while `removeHandler()` mutated it. On older CPython the list shrinks under the iterator, so it skips every other handler and some survive — which is precisely what the two `FIXME` comments were working around, since `clear_loggers()` had the same bug as the workarounds compensating for it. On the newer patches the iterator sees a stable snapshot and removes everything, so the public `clear_loggers()` behaved differently depending on the interpreter's patch version.

Fixed by iterating a copy in all three loops, with `clear_loggers()` explicitly attaching a `NullHandler` to preserve the state callers have always observed. No BC break on 3.0.x.

## Verification

Full 14/14 green on #806 before the mismerge, including the complete 7-leg matrix — the 3.13 and 3.14 legs resolve to 3.13.15 and 3.14.7, exercising both sides of the split.

Re-verified locally on this branch: `make comply` clean, **392 passed, 100% coverage**.

## Why this matters now

`main` is latently red: `Build & Test` only runs on `pull_request`, so nothing tests `main` directly, but every new PR merges into `main` and will fail on `test_clear_loggers`. That includes the five open Dependabot PRs — rebasing them before this lands would just fail them all again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GaMW9kaP2M236N6SXpCMnw

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logging handler cleanup consistency across supported Python versions.
  * Preserved a null logging handler after clearing configured handlers.
  * Improved console and file logging setup reliability when handlers are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->