### PR TITLE
fix(ext.redis): type-check clean under redis 7.x and 8.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ Bugs:
   handler-less logger. The loops now iterate a copy and `clear_loggers()`
   explicitly leaves a `NullHandler` attached, so behavior is identical on every
   supported interpreter and matches what callers have always observed.
+- `[ext.redis]` Replace unused `# type: ignore` suppressions in `delete()`
+  and `purge()` with `typing.cast()`. redis 8.1 narrowed the
+  `delete()`/`keys()` return annotations, which made the two suppressions
+  unused and failed the type-check gate under `warn_unused_ignores`. The
+  `redis` extra stays unpinned; the handler type-checks clean against both
+  redis 7.4.0 and 8.1.0.
 
 Features:
 

--- a/cement/ext/ext_redis.py
+++ b/cement/ext/ext_redis.py
@@ -11,7 +11,7 @@ extensions.
   dependencies.
 """
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import redis
 
@@ -128,8 +128,10 @@ class RedisCacheHandler(cache.CacheHandler):
             bool: ``True`` if the key is successfully deleted, ``False``
             otherwise
         """
-        res = self.r.delete(key)
-        return int(res) > 0  # type: ignore[arg-type]
+        # redis-py annotates sync and async client responses identically; this
+        # handler is sync-only, so the result is always the concrete value.
+        res = cast(int, self.r.delete(key))
+        return res > 0
 
     def purge(self, **kw: Any) -> None:
         """
@@ -138,9 +140,9 @@ class RedisCacheHandler(cache.CacheHandler):
         redis ``flush_all()`` function.
 
         """
-        keys = self.r.keys('*')
+        keys = cast('list[Any]', self.r.keys('*'))
         if keys:
-            self.r.delete(*keys)  # type: ignore[misc]
+            self.r.delete(*keys)
 
 
 def load(app: "App") -> None:


### PR DESCRIPTION
## Summary

CI's `comply` gate fails on [#811](https://github.com/datafolklabs/cement/pull/811) (the automated `pdm.lock` bump of `redis` 7.4.0 → 8.1.0). redis 8.1 narrowed the return annotations on `delete()` and `keys()` (`ResponseT` → `int | Awaitable[int]`), which makes the two `# type: ignore` suppressions in `RedisCacheHandler` unused. `warn_unused_ignores = true` (pyproject.toml:193) turns an unused suppression into an error, so `make comply` exits 2.

Replacing both suppressions with `typing.cast()` fixes it. A cast is not a suppression directive, so `warn_unused_ignores` can never flag it — the handler type-checks clean under **both** redis 7.4.0 and 8.1.0.

This is a standalone fix; it is not the lock bump. `pyproject.toml` and `pdm.lock` are untouched and #811 lands separately.

## Changes

**`cement/ext/ext_redis.py`**

- `delete()` — `res = cast(int, self.r.delete(key))`, replacing `int(res) > 0  # type: ignore[arg-type]`.
- `purge()` — `keys = cast('list[Any]', self.r.keys('*'))`, dropping `# type: ignore[misc]` from the `delete(*keys)` call.
- One comment records the why: redis-py annotates sync and async client responses identically, and this handler is sync-only.
- The `# type: ignore[union-attr]` on the `res.decode()` line in `get()` is deliberately untouched — still load-bearing under both redis versions.

**`CHANGELOG.md`** — `[ext.redis]` entry in the `3.0.17 - DEVELOPMENT` / Bugs bucket.

## No downstream constraint change

The alternative fix — flooring the `redis` extra to `>=8` — was rejected. It would drop redis 7.x for downstream users, which the compatibility-first policy for the 3.0.x track rules out. The `redis` extra stays unpinned (`redis = ["redis"]`).

## Acceptance status

| # | Criterion | Verification | Status |
|---|-----------|--------------|--------|
| D1 | Type-checks clean under redis 8.1.0 | `mypy --python-executable <redis-8.1.0-venv>/bin/python cement/ext/ext_redis.py` → `Success: no issues found` | ✅ |
| D1 | Type-checks clean under redis 7.4.0 | `make comply` (ruff + mypy, installed redis 7.4.0) → exit 0 | ✅ |
| D2 | Handler runtime behavior unchanged | `tests/ext/test_ext_redis.py` — 5 passed, 100.00% coverage on `cement/ext/ext_redis.py` | ✅ |
| D2 | Full suite green | `make test` — 392 passed, 100.00% total coverage | ✅ |
| D3 | Dependency surface untouched | `pyproject.toml` / `pdm.lock` absent from the diff | ✅ |

## Files touched

```
CHANGELOG.md            |  6 ++++++
cement/ext/ext_redis.py | 12 +++++++-----
2 files changed, 13 insertions(+), 5 deletions(-)
```

## Test plan

- [x] `make comply` — ruff clean, mypy clean across 51 source files
- [x] `mypy` against a redis 8.1.0 venv — clean
- [x] `mypy` against redis 7.4.0 (local install) — clean
- [x] `pdm run pytest tests/ext/test_ext_redis.py` — 5 passed, 100% coverage
- [x] `make test` — 392 passed, 100% total coverage
- [ ] Re-run CI on #811 once this merges; the `comply` gate should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RjdwAnb4UJjmDbTcVrHoCN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Redis 7.4.0 and 8.1.0 by ensuring delete and purge operations pass type validation cleanly.
* **Documentation**
  * Added a changelog entry documenting the Redis compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->